### PR TITLE
fix midi input

### DIFF
--- a/src/lib/audio/InitMidiButton.svelte
+++ b/src/lib/audio/InitMidiButton.svelte
@@ -5,7 +5,7 @@
 
 	// TODO move MIDI initialization to some other action, like the button to start a level
 
-	$: ma = midi_access?.midi_access;
+	$: ma = midi_access?.ma;
 	$: disabled = !midi_access || !!$ma;
 
 	$: midi_inputs = $ma && Array.from($ma.inputs.values());

--- a/src/lib/audio/MidiAccess.svelte
+++ b/src/lib/audio/MidiAccess.svelte
@@ -29,6 +29,7 @@
 		} catch (err) {
 			console.error('loadMidiAccess failed', err);
 			alert('Failed to request MIDI access: ' + err.message); // eslint-disable-line no-alert
+			// TODO resolve a failure value?
 		}
 		return inited;
 	};

--- a/src/lib/audio/MidiAccess.svelte
+++ b/src/lib/audio/MidiAccess.svelte
@@ -1,0 +1,35 @@
+<script lang="ts" context="module">
+	let global_midi_access: MIDIAccess | null = null;
+	let inited: Promise<void> | undefined;
+</script>
+
+<script lang="ts" accessors>
+	import {writable, type Writable} from 'svelte/store';
+
+	import type {MIDIAccess} from '$lib/audio/WebMIDI';
+	import {request_midi_access} from '$lib/audio/midi_helpers';
+
+	export const ma: Writable<MIDIAccess | null> = writable(global_midi_access);
+
+	export const init = async (): Promise<void> => {
+		if (inited) return inited;
+		inited = Promise.resolve();
+		if (global_midi_access) {
+			$ma = global_midi_access;
+			return inited;
+		}
+		// TODO how to call this better? needs to be a user-initiated action right?
+		// do we need to present a screen to users that lets them opt into midi?
+		try {
+			$ma = global_midi_access = await request_midi_access();
+			console.log('requested midi_access', $ma);
+			if (!$ma) {
+				throw Error(`Cannot list midi inputs without access`);
+			}
+		} catch (err) {
+			console.error('loadMidiAccess failed', err);
+			alert('Failed to request MIDI access: ' + err.message); // eslint-disable-line no-alert
+		}
+		return inited;
+	};
+</script>

--- a/src/lib/audio/MidiInput.svelte
+++ b/src/lib/audio/MidiInput.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" accessors>
+<script lang="ts">
 	import {createEventDispatcher, onDestroy} from 'svelte';
 	import type {Writable} from 'svelte/store';
 

--- a/src/lib/audio/MidiInput.svelte
+++ b/src/lib/audio/MidiInput.svelte
@@ -20,6 +20,8 @@
 
 	export let ma: Writable<MIDIAccess | null>;
 
+	console.log('ma', ma);
+
 	const midimessage = (event: MIDIMessageEvent): void => {
 		const message = parse_midi_message(event);
 		const {command, channel, note, velocity} = message;
@@ -82,6 +84,7 @@
 	onDestroy(unsubscribe);
 
 	const subscribe = ($ma: MIDIAccess | null) => {
+		log(`subscribe $ma`, $ma);
 		if (unsubscribers.length) unsubscribe();
 		if (!$ma) return;
 		for (const input of $ma.inputs.values()) {

--- a/src/lib/audio/MidiInput.svelte
+++ b/src/lib/audio/MidiInput.svelte
@@ -18,7 +18,7 @@
 		mod_wheel: number; // velocity
 	}>();
 
-	export let midi_access: Writable<MIDIAccess | null>;
+	export let ma: Writable<MIDIAccess | null>;
 
 	const midimessage = (event: MIDIMessageEvent): void => {
 		const message = parse_midi_message(event);
@@ -81,10 +81,10 @@
 	};
 	onDestroy(unsubscribe);
 
-	const subscribe = ($midi_access: MIDIAccess | null) => {
+	const subscribe = ($ma: MIDIAccess | null) => {
 		if (unsubscribers.length) unsubscribe();
-		if (!$midi_access) return;
-		for (const input of $midi_access.inputs.values()) {
+		if (!$ma) return;
+		for (const input of $ma.inputs.values()) {
 			log('subscribing to midi input', input);
 			input.addEventListener('midimessage', midimessage as any);
 			unsubscribers.push(() => {
@@ -94,5 +94,5 @@
 		}
 	};
 
-	$: subscribe($midi_access);
+	$: subscribe($ma);
 </script>

--- a/src/lib/audio/MidiInput.svelte
+++ b/src/lib/audio/MidiInput.svelte
@@ -1,14 +1,9 @@
-<script lang="ts" context="module">
-	let global_midi_access: MIDIAccess | null = null;
-	let inited: Promise<void> | undefined;
-</script>
-
 <script lang="ts" accessors>
-	import {createEventDispatcher} from 'svelte';
-	import {writable} from 'svelte/store';
+	import {createEventDispatcher, onDestroy} from 'svelte';
+	import type {Writable} from 'svelte/store';
 
-	import {type MIDIAccess, type MIDIMessageEvent, MIDICommand} from '$lib/audio/WebMIDI';
-	import {request_midi_access, parse_midi_message} from '$lib/audio/midi_helpers';
+	import {type MIDIMessageEvent, MIDICommand, type MIDIAccess} from '$lib/audio/WebMIDI';
+	import {parse_midi_message} from '$lib/audio/midi_helpers';
 	import type {Midi} from '$lib/music/midi';
 
 	// This component uses
@@ -23,39 +18,12 @@
 		mod_wheel: number; // velocity
 	}>();
 
-	export const midi_access = writable(global_midi_access);
+	export let midi_access: Writable<MIDIAccess | null>;
 
-	export const init = async (): Promise<void> => {
-		if (inited) return inited;
-		inited = Promise.resolve();
-		if (global_midi_access) {
-			$midi_access = global_midi_access;
-			return inited;
-		}
-		// TODO how to call this better? needs to be a user-initiated action right?
-		// do we need to present a screen to users that lets them opt into midi?
-		try {
-			$midi_access = global_midi_access = await request_midi_access();
-			console.log('requested midi_access', $midi_access);
-			if (!$midi_access) {
-				throw Error(`Cannot list midi inputs without access`);
-			}
-			for (const input of $midi_access.inputs.values()) {
-				log('midi input', input);
-				input.onmidimessage = on_midi_message;
-			}
-			console.log('MIDI ready!');
-		} catch (err) {
-			console.error('loadMidiAccess failed', err);
-			alert('Failed to request MIDI access: ' + err.message); // eslint-disable-line no-alert
-		}
-		return inited;
-	};
-
-	const on_midi_message = (event: MIDIMessageEvent): void => {
+	const midimessage = (event: MIDIMessageEvent): void => {
 		const message = parse_midi_message(event);
 		const {command, channel, note, velocity} = message;
-		log('on_midi_message', command, message);
+		log('midimessage', command, message);
 
 		switch (command) {
 			case MIDICommand.Stop: {
@@ -105,4 +73,26 @@
 			}
 		}
 	};
+
+	const unsubscribers: Array<() => void> = [];
+	const unsubscribe = (): void => {
+		for (const u of unsubscribers) u();
+		unsubscribers.length = 0;
+	};
+	onDestroy(unsubscribe);
+
+	const subscribe = ($midi_access: MIDIAccess | null) => {
+		if (unsubscribers.length) unsubscribe();
+		if (!$midi_access) return;
+		for (const input of $midi_access.inputs.values()) {
+			log('subscribing to midi input', input);
+			input.addEventListener('midimessage', midimessage as any);
+			unsubscribers.push(() => {
+				log('unsubscribing to midi input', input);
+				input.removeEventListener('midimessage', midimessage as any);
+			});
+		}
+	};
+
+	$: subscribe($midi_access);
 </script>

--- a/src/lib/audio/VolumeControl.svelte
+++ b/src/lib/audio/VolumeControl.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import type {Writable} from 'svelte/store';
 
-	export let volume: Writable<number>;
+	import type {Volume} from '$lib/audio/helpers';
+
+	export let volume: Writable<Volume>;
 </script>
 
 <div class="volume-control">

--- a/src/lib/audio/helpers.ts
+++ b/src/lib/audio/helpers.ts
@@ -2,19 +2,6 @@ import {getContext, setContext} from 'svelte';
 import {writable, type Writable} from 'svelte/store';
 import type {Flavored} from '@feltjs/util';
 
-/**
- * Convert a user-facing volume value [0,1] to the actual gain value.
- * We want some sort of nonlinear curve to match user expectations.
- * TODO why is this exponent so different from the article? this sounds better to me
- * https://www.dr-lex.be/info-stuff/volumecontrols.html
- */
-export const VOLUME_TO_GAIN_EXPONENT = 2.2;
-export const volume_to_gain = (volume: number): number => {
-	return volume ** VOLUME_TO_GAIN_EXPONENT;
-};
-
-export const SMOOTH_GAIN_TIME_CONSTANT = 0.03;
-
 export type Frequency = Flavored<number, 'Frequency'>;
 export type Milliseconds = Flavored<number, 'Milliseconds'>;
 export type Volume = Flavored<number, 'Volume'>;
@@ -25,3 +12,14 @@ const KEY = Symbol('volume');
 export const get_volume = (): Writable<Volume> => getContext(KEY);
 export const set_volume = (store = writable(DEFAULT_VOLUME)): Writable<Volume> =>
 	setContext(KEY, store);
+
+/**
+ * Convert a user-facing volume value [0,1] to the actual gain value.
+ * We want some sort of nonlinear curve to match user expectations.
+ * TODO why is this exponent so different from the article? this sounds better to me
+ * https://www.dr-lex.be/info-stuff/volumecontrols.html
+ */
+export const VOLUME_TO_GAIN_EXPONENT = 2.2;
+export const volume_to_gain = (volume: Volume): number => volume ** VOLUME_TO_GAIN_EXPONENT;
+
+export const SMOOTH_GAIN_TIME_CONSTANT = 0.03;

--- a/src/lib/audio/helpers.ts
+++ b/src/lib/audio/helpers.ts
@@ -1,5 +1,6 @@
 import {getContext, setContext} from 'svelte';
 import {writable, type Writable} from 'svelte/store';
+import type {Flavored} from '@feltjs/util';
 
 /**
  * Convert a user-facing volume value [0,1] to the actual gain value.
@@ -14,11 +15,13 @@ export const volume_to_gain = (volume: number): number => {
 
 export const SMOOTH_GAIN_TIME_CONSTANT = 0.03;
 
-export type Frequency = number;
+export type Frequency = Flavored<number, 'Frequency'>;
+export type Milliseconds = Flavored<number, 'Milliseconds'>;
+export type Volume = Flavored<number, 'Volume'>;
 
-export const DEFAULT_VOLUME = 0.51;
+export const DEFAULT_VOLUME: Volume = 0.51;
 
 const KEY = Symbol('volume');
-export const get_volume = (): Writable<number> => getContext(KEY);
-export const set_volume = (store = writable(DEFAULT_VOLUME)): Writable<number> =>
+export const get_volume = (): Writable<Volume> => getContext(KEY);
+export const set_volume = (store = writable(DEFAULT_VOLUME)): Writable<Volume> =>
 	setContext(KEY, store);

--- a/src/lib/audio/play_note.ts
+++ b/src/lib/audio/play_note.ts
@@ -1,10 +1,11 @@
-import type {Flavored} from '@feltjs/util';
-
-import {DEFAULT_VOLUME, SMOOTH_GAIN_TIME_CONSTANT, volume_to_gain} from '$lib/audio/helpers';
+import {
+	DEFAULT_VOLUME,
+	SMOOTH_GAIN_TIME_CONSTANT,
+	volume_to_gain,
+	type Milliseconds,
+	type Volume,
+} from '$lib/audio/helpers';
 import {type Midi, midi_to_freq} from '$lib/music/midi';
-
-export type Milliseconds = Flavored<number, 'Milliseconds'>;
-export type Volume = Flavored<number, 'Volume'>;
 
 // TODO this API is haphazard, rethink all of it
 
@@ -41,7 +42,7 @@ export interface StopPlaying {
 export const start_playing_note = (
 	audio_ctx: AudioContext,
 	note: Midi,
-	volume = DEFAULT_VOLUME,
+	volume: Volume = DEFAULT_VOLUME,
 ): StopPlaying => {
 	const freq = midi_to_freq(note);
 	console.log('start playing note', note, freq);
@@ -66,7 +67,7 @@ export const start_playing_note = (
 
 const playing: Map<Midi, StopPlaying> = new Map(); // global cache used to enforce that at most one of each note plays
 
-export const start_playing = (audio_ctx: AudioContext, note: Midi, volume?: number): void => {
+export const start_playing = (audio_ctx: AudioContext, note: Midi, volume?: Volume): void => {
 	const current = playing.get(note);
 	if (current) return;
 	playing.set(note, start_playing_note(audio_ctx, note, volume));

--- a/src/lib/audio/play_note.ts
+++ b/src/lib/audio/play_note.ts
@@ -5,6 +5,8 @@ import {type Midi, midi_to_freq} from '$lib/music/midi';
 
 export type Milliseconds = Flavored<number, 'Milliseconds'>;
 
+// TODO this API is haphazard, rethink all of it
+
 export const play_note = (
 	audio_ctx: AudioContext,
 	note: Midi,

--- a/src/lib/audio/play_note.ts
+++ b/src/lib/audio/play_note.ts
@@ -4,30 +4,23 @@ import {DEFAULT_VOLUME, SMOOTH_GAIN_TIME_CONSTANT, volume_to_gain} from '$lib/au
 import {type Midi, midi_to_freq} from '$lib/music/midi';
 
 export type Milliseconds = Flavored<number, 'Milliseconds'>;
+export type Volume = Flavored<number, 'Volume'>;
 
 // TODO this API is haphazard, rethink all of it
 
 export const play_note = (
 	audio_ctx: AudioContext,
 	note: Midi,
+	volume: Volume,
 	duration: Milliseconds,
-	volume: number,
 ): Promise<void> => {
-	const freq = midi_to_freq(note);
-	console.log('playing note', note, freq);
-
-	const gain = audio_ctx.createGain();
-	gain.gain.value = volume_to_gain(volume);
-	gain.connect(audio_ctx.destination);
-	const osc = audio_ctx.createOscillator();
-	osc.type = 'sine'; // TODO "custom" | "sawtooth" | "sine" | "square" | "triangle"
-	osc.frequency.setValueAtTime(freq, audio_ctx.currentTime);
-	osc.start();
-	osc.connect(gain);
-
-	stop_osc(audio_ctx, duration, gain, osc);
-
-	return new Promise((r) => setTimeout(r, duration));
+	const stop = start_playing_note(audio_ctx, note, volume);
+	return new Promise((resolve) =>
+		setTimeout(() => {
+			stop();
+			resolve();
+		}, duration),
+	);
 };
 
 const stop_osc = (

--- a/src/lib/audio/play_note.ts
+++ b/src/lib/audio/play_note.ts
@@ -71,7 +71,6 @@ export const start_playing_note = (
 // Helpers to play a single note at a time.
 // Maybe this should be put in the main context and wrap `audio_ctx` so it's not accessed directly?
 
-// TODO allow playing notes at different volumes using velocity
 const playing: Map<Midi, StopPlaying> = new Map(); // global cache used to enforce that at most one of each note plays
 
 export const start_playing = (audio_ctx: AudioContext, note: Midi, volume?: number): void => {

--- a/src/lib/earworm/Earworm.svelte
+++ b/src/lib/earworm/Earworm.svelte
@@ -8,7 +8,7 @@
 	import {create_level_stats} from '$lib/earworm/level_stats';
 	import Level from '$lib/earworm/Level.svelte';
 	import {get_audio_ctx} from '$lib/audio/audio_ctx';
-	import MidiInput from '$lib/audio/MidiInput.svelte';
+	import MidiAccess from '$lib/audio/MidiAccess.svelte';
 
 	export let default_level_defs = level_defs; // is a bit awkward, doing it this way to allow custom games, and removing both kinds
 	export let active_level_def: LevelDef | null = null;
@@ -25,7 +25,7 @@
 	const audio_ctx = get_audio_ctx();
 	(window as any).audio = audio_ctx;
 
-	let midi_input: MidiInput;
+	let midi_access: MidiAccess | undefined;
 
 	const select_level_def = async (id: LevelId): Promise<void> => {
 		const level_def = all_level_defs.find((d) => d.id === id);
@@ -103,15 +103,15 @@
 	};
 </script>
 
-<MidiInput bind:this={midi_input} />
+<MidiAccess bind:this={midi_access} />
 {#if active_level_def}
 	<div class="level">
 		<Level level_def={active_level_def} {exit_level_to_map} />
 	</div>
-{:else}
+{:else if midi_access}
 	<slot name="header" />
 	<LevelMap
-		{midi_input}
+		{midi_access}
 		level_def={editing_level_def}
 		level_defs={all_level_defs}
 		{select_level_def}

--- a/src/lib/earworm/Level.svelte
+++ b/src/lib/earworm/Level.svelte
@@ -106,7 +106,7 @@
 
 <svelte:window on:keydown={keydown} />
 <MidiAccess bind:this={midi_access} />
-{#if $ma}
+{#if ma}
 	<MidiInput
 		{ma}
 		on:note_start={(e) => {

--- a/src/lib/earworm/Level.svelte
+++ b/src/lib/earworm/Level.svelte
@@ -11,6 +11,7 @@
 	import type {Midi} from '$lib/music/midi';
 	import {start_playing, stop_playing} from '$lib/audio/play_note';
 	import {get_volume} from '$lib/audio/helpers';
+	import MidiAccess from '$lib/audio/MidiAccess.svelte';
 
 	/*
 
@@ -37,6 +38,9 @@
 
 	const level = create_level_store(level_def, audio_ctx, volume);
 	// $: level.setDef(level_def); // TODO update if level_def prop changes
+
+	let midi_access: MidiAccess;
+	$: ma = midi_access?.ma;
 
 	$: highlighted_keys = $level.trial && new Set([$level.trial.sequence[0]]);
 
@@ -101,13 +105,17 @@
 </script>
 
 <svelte:window on:keydown={keydown} />
-<MidiInput
-	on:note_start={(e) => {
-		// TODO should this be ignored if it's not an enabled key? should the level itself ignore the guess?
-		console.log(`e`, e);
-		level.guess(e.detail.note);
-	}}
-/>
+<MidiAccess bind:this={midi_access} />
+{#if $ma}
+	<MidiInput
+		{ma}
+		on:note_start={(e) => {
+			// TODO should this be ignored if it's not an enabled key? should the level itself ignore the guess?
+			console.log(`e`, e);
+			level.guess(e.detail.note);
+		}}
+	/>
+{/if}
 <!-- hide from screen readers, see keyboard commands -->
 <div class="level" bind:clientWidth on:click={click} bind:this={el} aria-hidden="true">
 	<!-- <div class="debug">

--- a/src/lib/earworm/Level.svelte
+++ b/src/lib/earworm/Level.svelte
@@ -111,8 +111,14 @@
 		{ma}
 		on:note_start={(e) => {
 			// TODO should this be ignored if it's not an enabled key? should the level itself ignore the guess?
-			console.log(`e`, e);
-			level.guess(e.detail.note);
+			if ($level.status === 'complete') {
+				start_playing(audio_ctx, e.detail.note, $volume);
+			} else {
+				level.guess(e.detail.note);
+			}
+		}}
+		on:note_stop={(e) => {
+			stop_playing(e.detail.note);
 		}}
 	/>
 {/if}

--- a/src/lib/earworm/LevelMap.svelte
+++ b/src/lib/earworm/LevelMap.svelte
@@ -4,7 +4,7 @@
 	import LevelMapItem from '$lib/earworm/LevelMapItem.svelte';
 	import {get_audio_ctx} from '$lib/audio/audio_ctx';
 	import type MidiAccess from '$lib/audio/MidiAccess.svelte';
-	import InitMidiButton from '$lib/music/InitMidiButton.svelte';
+	import InitMidiButton from '$lib/audio/InitMidiButton.svelte';
 	import LevelDefForm from '$lib/earworm/LevelDefForm.svelte';
 	import VolumeControl from '$lib/audio/VolumeControl.svelte';
 	import {get_volume} from '$lib/audio/helpers';

--- a/src/lib/earworm/LevelMap.svelte
+++ b/src/lib/earworm/LevelMap.svelte
@@ -3,13 +3,13 @@
 	import {create_level_stats} from '$lib/earworm/level_stats';
 	import LevelMapItem from '$lib/earworm/LevelMapItem.svelte';
 	import {get_audio_ctx} from '$lib/audio/audio_ctx';
-	import type MidiInput from '$lib/audio/MidiInput.svelte';
+	import type MidiAccess from '$lib/audio/MidiAccess.svelte';
 	import InitMidiButton from '$lib/music/InitMidiButton.svelte';
 	import LevelDefForm from '$lib/earworm/LevelDefForm.svelte';
 	import VolumeControl from '$lib/audio/VolumeControl.svelte';
 	import {get_volume} from '$lib/audio/helpers';
 
-	export let midi_input: MidiInput;
+	export let midi_access: MidiAccess;
 	export let level_def: LevelDef | null = null;
 	export let level_defs: LevelDef[];
 	export let select_level_def: ((id: LevelId) => void) | null = null; // TODO event? or is the ability to have a return value for ephemeral state desired?
@@ -62,7 +62,7 @@
 			Earworm supports MIDI devices like piano keyboards. Connect a device and click the button
 			below:
 		</p>
-		<InitMidiButton {midi_input} />
+		<InitMidiButton {midi_access} />
 	</section>
 	<section class="panel padded-md column-sm">
 		<header class="markup">

--- a/src/lib/earworm/level.ts
+++ b/src/lib/earworm/level.ts
@@ -164,7 +164,7 @@ export const create_level_store = (
 	// TODO helpful to have a return value?
 	const guess = (note: Midi): void => {
 		update(($level) => {
-			if ($level.status !== 'waiting_for_input') throw Error();
+			if ($level.status !== 'waiting_for_input') return $level;
 			if (!$level.trial || $level.trial.guessing_index === null) {
 				throw Error(`Expected a trial and guessing_index`);
 			}

--- a/src/lib/earworm/level.ts
+++ b/src/lib/earworm/level.ts
@@ -148,7 +148,7 @@ export const create_level_store = (
 					presenting_index: i,
 				},
 			}));
-			await play_note(audio_ctx, note, DEFAULT_NOTE_DURATION, get(volume)); // eslint-disable-line no-await-in-loop
+			await play_note(audio_ctx, note, get(volume), DEFAULT_NOTE_DURATION); // eslint-disable-line no-await-in-loop
 		}
 		update(($level) => ({
 			...$level,
@@ -175,7 +175,7 @@ export const create_level_store = (
 			// if incorrect -> FAILURE -> showing_failure_feedback -> REPROMPT
 			if (actual !== note) {
 				console.log('guess INCORRECT');
-				void play_note(audio_ctx, note, DEFAULT_NOTE_DURATION_FAILED, get(volume));
+				void play_note(audio_ctx, note, get(volume), DEFAULT_NOTE_DURATION_FAILED);
 				if ($level.trial.guessing_index === 0) {
 					return $level; // no penalty or delay if this is the first one
 				}
@@ -188,7 +188,7 @@ export const create_level_store = (
 			}
 
 			// guess is correct
-			void play_note(audio_ctx, note, DEFAULT_NOTE_DURATION, get(volume));
+			void play_note(audio_ctx, note, get(volume), DEFAULT_NOTE_DURATION);
 
 			if ($level.trial.guessing_index >= $level.trial.sequence.length - 1) {
 				// if more -> update current response index

--- a/src/lib/earworm/level.ts
+++ b/src/lib/earworm/level.ts
@@ -5,6 +5,7 @@ import type {Midi} from '$lib/music/midi';
 import type {Semitones} from '$lib/music/notes';
 import {play_note} from '$lib/audio/play_note';
 import type {Flavored} from '@feltjs/util';
+import type {Volume} from '$lib/audio/helpers';
 
 export const DEFAULT_NOTE_DURATION = 500;
 export const DEFAULT_NOTE_DURATION_FAILED = 50;
@@ -115,7 +116,7 @@ const to_default_state = (level_def: LevelDef): LevelStoreState => ({
 export const create_level_store = (
 	level_def: LevelDef,
 	audio_ctx: AudioContext,
-	volume: Writable<number>,
+	volume: Writable<Volume>,
 ): LevelStore => {
 	const {subscribe, update, set} = writable<LevelStoreState>(to_default_state(level_def));
 

--- a/src/lib/earworm/level_defs.ts
+++ b/src/lib/earworm/level_defs.ts
@@ -16,27 +16,36 @@ export const BASE_LEVEL_DEF = {
 	note_max: 84,
 } satisfies Partial<LevelDef>;
 
+// TODO programmatic dimensions
+// "up and down" (duplicate the intervals below the tonic)
+// "long" (sequent_length multiplier)
+
 export const level_defs: LevelDef[] = [
 	{
-		name: '5 12',
+		name: 'perfect fourth vs perfect octave',
 		intervals: [5, 12],
 		sequence_length: 2,
 	},
 	{
-		name: '4 7',
+		name: 'major third vs perfect fifth',
 		intervals: [4, 7],
 		sequence_length: 2,
 	},
 	{
-		name: '2 12 -1 -12',
-		intervals: [2, 12, -1, -12],
+		name: 'major third vs perfect fourth vs perfect fifth vs perfect octave',
+		intervals: [4, 5, 7, 12],
+		sequence_length: 2,
 	},
 	{
-		name: '2 4 7',
+		name: 'major second vs perfect octave up and down',
+		intervals: [2, 12, -10, -12],
+	},
+	{
+		name: 'major second vs major third vs perfect fifth',
 		intervals: [2, 4, 7],
 	},
 	{
-		name: '2 4 7 (long)',
+		name: 'major second vs major third vs perfect fifth (long)',
 		intervals: [2, 4, 7],
 		sequence_length: DEFAULT_SEQUENCE_LENGTH * 2,
 	},
@@ -50,12 +59,12 @@ export const level_defs: LevelDef[] = [
 		sequence_length: DEFAULT_SEQUENCE_LENGTH * 2,
 	},
 	{
-		name: '4 7 12 -4 -7 -12',
-		intervals: [4, 7, 12, -4, -7, -12],
+		name: '4 7 12 -5 -8 -12',
+		intervals: [4, 7, 12, -5, -8, -12],
 	},
 	{
-		name: '4 7 12 -4 -7 -12 (long)',
-		intervals: [4, 7, 12, -4, -7, -12],
+		name: '4 7 12 -5 -8 -12 (long)',
+		intervals: [4, 7, 12, -5, -8, -12],
 		sequence_length: DEFAULT_SEQUENCE_LENGTH * 2,
 	},
 	{
@@ -64,13 +73,13 @@ export const level_defs: LevelDef[] = [
 		sequence_length: DEFAULT_SEQUENCE_LENGTH * 2,
 	},
 	{
-		name: '1 2 (long)',
-		intervals: [1, 2],
+		name: '2 4 (long)',
+		intervals: [2, 4],
 		sequence_length: DEFAULT_SEQUENCE_LENGTH * 2,
 	},
 	{
-		name: '2 3 (long)',
-		intervals: [2, 3],
+		name: '2 4 5 (long)',
+		intervals: [2, 4, 5],
 		sequence_length: DEFAULT_SEQUENCE_LENGTH * 2,
 	},
 	{

--- a/src/lib/earworm/level_defs.ts
+++ b/src/lib/earworm/level_defs.ts
@@ -100,4 +100,12 @@ export const level_defs: LevelDef[] = [
 		intervals: [2, 4, 5, 7, 9, 11, 12, 14, 16, 17, 19, 21, 23, 24],
 		sequence_length: DEFAULT_SEQUENCE_LENGTH * 2,
 	},
+	{
+		name: 'two octaves',
+		intervals: Array.from({length: 25}, (_, i) => i - 12),
+	},
+	{
+		name: 'four octaves',
+		intervals: Array.from({length: 49}, (_, i) => i - 24),
+	},
 ].map((d) => ({...BASE_LEVEL_DEF, ...d, id: create_id()}));

--- a/src/lib/earworm/level_defs.ts
+++ b/src/lib/earworm/level_defs.ts
@@ -19,6 +19,8 @@ export const BASE_LEVEL_DEF = {
 // TODO programmatic dimensions
 // "up and down" (duplicate the intervals below the tonic)
 // "long" (sequent_length multiplier)
+// which keys can be used
+// present_duration
 
 export const level_defs: LevelDef[] = [
 	{

--- a/src/lib/music/InitMidiButton.svelte
+++ b/src/lib/music/InitMidiButton.svelte
@@ -1,24 +1,24 @@
 <script lang="ts">
-	import type MidiInput from '$lib/audio/MidiInput.svelte';
+	import type MidiAccess from '$lib/audio/MidiAccess.svelte';
 
-	export let midi_input: MidiInput | undefined;
+	export let midi_access: MidiAccess | undefined;
 
 	// TODO move MIDI initialization to some other action, like the button to start a level
 
-	$: midi_access = midi_input?.midi_access;
-	$: disabled = !midi_input || !!$midi_access;
+	$: ma = midi_access?.midi_access;
+	$: disabled = !midi_access || !!$ma;
 
-	$: midi_inputs = $midi_access && Array.from($midi_access.inputs.values());
+	$: midi_inputs = $ma && Array.from($ma.inputs.values());
 </script>
 
 <button
 	type="button"
 	class="big"
-	on:click={() => void midi_input?.init()}
+	on:click={() => void midi_access?.init()}
 	{disabled}
-	title={midi_input ? ($midi_access ? 'MIDI is ready!' : 'connect your MIDI device') : 'loading...'}
+	title={midi_access ? ($ma ? 'MIDI is ready!' : 'connect your MIDI device') : 'loading...'}
 >
-	{#if $midi_access}
+	{#if $ma}
 		{#if midi_inputs?.length}
 			🎶
 			{#each midi_inputs as midi_input}

--- a/src/routes/piano/+page.svelte
+++ b/src/routes/piano/+page.svelte
@@ -62,7 +62,7 @@
 			<VolumeControl {volume} />
 		</fieldset>
 		<fieldset>
-			<InitMidiButton {midi_input} />
+			<InitMidiButton midi_access={midi_input} />
 		</fieldset>
 	</form>
 	<Footer />

--- a/src/routes/piano/+page.svelte
+++ b/src/routes/piano/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Piano from '$lib/music/Piano.svelte';
 	import {get_audio_ctx} from '$lib/audio/audio_ctx';
+	import MidiAccess from '$lib/audio/MidiAccess.svelte';
 	import MidiInput from '$lib/audio/MidiInput.svelte';
 	import {MIDI_MAX, MIDI_MIN, type Midi} from '$lib/music/midi';
 	import {start_playing, stop_playing} from '$lib/audio/play_note';
@@ -13,7 +14,8 @@
 	const audio_ctx = get_audio_ctx();
 	const volume = get_volume();
 
-	let midi_input: MidiInput | undefined;
+	let midi_access: MidiAccess | undefined;
+	$: ma = midi_access?.ma;
 
 	let clientWidth: number; // `undefined` on first render
 
@@ -27,13 +29,16 @@
 	<title>earworm: piano</title>
 </svelte:head>
 
-<main bind:clientWidth>
-	<Header />
+<MidiAccess bind:this={midi_access} />
+{#if ma}
 	<MidiInput
-		bind:this={midi_input}
+		{ma}
 		on:note_start={(e) => start_playing(audio_ctx, e.detail.note, $volume)}
 		on:note_stop={(e) => stop_playing(e.detail.note)}
 	/>
+{/if}
+<main bind:clientWidth>
+	<Header />
 	<div class="piano-wrapper" style:padding="{piano_padding}px">
 		{#if clientWidth}
 			<Piano
@@ -62,7 +67,7 @@
 			<VolumeControl {volume} />
 		</fieldset>
 		<fieldset>
-			<InitMidiButton midi_access={midi_input} />
+			<InitMidiButton {midi_access} />
 		</fieldset>
 	</form>
 	<Footer />

--- a/src/routes/piano/+page.svelte
+++ b/src/routes/piano/+page.svelte
@@ -5,7 +5,7 @@
 	import MidiInput from '$lib/audio/MidiInput.svelte';
 	import {MIDI_MAX, MIDI_MIN, type Midi} from '$lib/music/midi';
 	import {start_playing, stop_playing} from '$lib/audio/play_note';
-	import InitMidiButton from '$lib/music/InitMidiButton.svelte';
+	import InitMidiButton from '$lib/audio/InitMidiButton.svelte';
 	import VolumeControl from '$lib/audio/VolumeControl.svelte';
 	import Header from '$routes/Header.svelte';
 	import Footer from '$routes/Footer.svelte';


### PR DESCRIPTION
They way I was listening to the MIDI inputs was broken, this fixes it.

followup:

- animate pressed piano keys based on what's playing in the audio layer
- animate the tonic when ready to start
- turn `level.ts` into a component and use `@preactjs/signals` with `accessors` for exported const stores
- more level defs
- show level history/stats/achievements visually on the map
- level unlocks
- create a level def with a form (and import/export json)
- show interval info on the trial?
