### PR TITLE
show piano keys pressed from audio state

### DIFF
--- a/src/lib/audio/InitMidiButton.svelte
+++ b/src/lib/audio/InitMidiButton.svelte
@@ -20,10 +20,15 @@
 >
 	{#if $ma}
 		{#if midi_inputs?.length}
-			🎶
-			{#each midi_inputs as midi_input}
-				{midi_input.name} ({midi_input.type}, {midi_input.manufacturer}, {midi_input.id})
-			{/each}
+			<div>🎶</div>
+			<table>
+				{#each midi_inputs as midi_input}
+					<tr>
+						<th><small>{midi_input.name}</small></th>
+						<th><small>{midi_input.id}</small></th>
+					</tr>
+				{/each}
+			</table>
 		{:else}
 			no MIDI devices found :[
 		{/if}
@@ -31,3 +36,9 @@
 		init MIDI
 	{/if}
 </button>
+
+<style>
+	th {
+		padding: 0 var(--spacing_sm);
+	}
+</style>

--- a/src/lib/audio/play_note.ts
+++ b/src/lib/audio/play_note.ts
@@ -9,7 +9,7 @@ import {type Midi, midi_to_freq} from '$lib/music/midi';
 import {writable, type Writable} from 'svelte/store';
 
 // TODO this API is haphazard, in particular `play_note` versus `start_playing` and `stop_playing`,
-// and we need to support more options
+// and we need to support more options like `velocity`
 
 export const play_note = (
 	audio_ctx: AudioContext,

--- a/src/lib/audio/play_note.ts
+++ b/src/lib/audio/play_note.ts
@@ -9,7 +9,7 @@ import {type Midi, midi_to_freq} from '$lib/music/midi';
 import {writable, type Writable} from 'svelte/store';
 
 // TODO this API is haphazard, in particular `play_note` versus `start_playing` and `stop_playing`,
-// and we need to support more options like `velocity`
+// and we need to support more options like `velocity`, should probably have a single options object
 
 export const play_note = (
 	audio_ctx: AudioContext,

--- a/src/lib/earworm/Level.svelte
+++ b/src/lib/earworm/Level.svelte
@@ -9,7 +9,7 @@
 	import {get_audio_ctx} from '$lib/audio/audio_ctx';
 	import MidiInput from '$lib/audio/MidiInput.svelte';
 	import type {Midi} from '$lib/music/midi';
-	import {start_playing, stop_playing} from '$lib/audio/play_note';
+	import {playing_notes, start_playing, stop_playing} from '$lib/audio/play_note';
 	import {get_volume} from '$lib/audio/helpers';
 	import MidiAccess from '$lib/audio/MidiAccess.svelte';
 
@@ -42,6 +42,7 @@
 	let midi_access: MidiAccess;
 	$: ma = midi_access?.ma;
 
+	$: pressed_keys = $playing_notes;
 	$: highlighted_keys = $level.trial && new Set([$level.trial.sequence[0]]);
 
 	onMount(() => {
@@ -165,14 +166,15 @@
 				width={clientWidth - piano_padding * 2}
 				note_min={$level.def.note_min}
 				note_max={$level.def.note_max}
+				enabled_keys={$level.trial?.valid_notes}
+				{pressed_keys}
+				{highlighted_keys}
 				on:press={$level.status === 'waiting_for_input'
 					? (e) => on_press_key(e.detail)
 					: $level.status === 'complete'
 					? (e) => start_playing(audio_ctx, e.detail, $volume)
 					: undefined}
 				on:release={$level.status === 'complete' ? (e) => stop_playing(e.detail) : undefined}
-				enabled_keys={$level.trial?.valid_notes}
-				{highlighted_keys}
 			/>
 		{/if}
 	</div>

--- a/src/lib/earworm/level_defs.ts
+++ b/src/lib/earworm/level_defs.ts
@@ -37,9 +37,16 @@ export const level_defs: LevelDef[] = [
 		sequence_length: 2,
 	},
 	{
-		name: 'major third vs perfect fourth vs perfect fifth vs perfect octave',
-		intervals: [4, 5, 7, 12],
+		name: 'major third vs perfect fourth vs perfect fifth',
+		intervals: [4, 5, 7],
 		sequence_length: 2,
+	},
+	{
+		name: 'major second vs major third',
+		intervals: [2, 4],
+		// TODO variants: ['up_and_down']
+		// {up_and_down: {options}} (allows options)
+		// {type: 'up_and_down', options}} (allows multiple of each variant with options)
 	},
 	{
 		name: 'major second vs perfect octave up and down',

--- a/src/lib/music/Piano.svelte
+++ b/src/lib/music/Piano.svelte
@@ -7,17 +7,9 @@
 	export let note_min: Midi = MIDI_MIN;
 	export let note_max: Midi = MIDI_MAX;
 	export let enabled_keys: Set<Midi> | null = null;
+	export let pressed_keys: Set<Midi> | null = null;
 	export let highlighted_keys: Set<Midi> | null = null;
 	export let emphasized_keys: Set<Midi> | null = null;
-
-	const is_key_enabled = (key: Midi, enabled_keys: Set<Midi> | null): boolean =>
-		!enabled_keys || enabled_keys.has(key);
-
-	const is_key_highlighted = (key: Midi, highlighted_keys: Set<Midi> | null): boolean =>
-		!!highlighted_keys?.has(key);
-
-	const is_key_emphasized = (key: Midi, emphasized_keys: Set<Midi> | null): boolean =>
-		!!emphasized_keys?.has(key);
 
 	$: ({
 		piano_keys,
@@ -43,9 +35,10 @@
 				on:release
 				{midi}
 				{left_offset}
-				enabled={is_key_enabled(midi, enabled_keys)}
-				highlighted={is_key_highlighted(midi, highlighted_keys)}
-				emphasized={is_key_emphasized(midi, emphasized_keys)}
+				enabled={!enabled_keys || enabled_keys.has(midi)}
+				pressed={pressed_keys?.has(midi)}
+				highlighted={highlighted_keys?.has(midi)}
+				emphasized={emphasized_keys?.has(midi)}
 			/>
 		{/each}
 	</div>

--- a/src/lib/music/PianoKey.svelte
+++ b/src/lib/music/PianoKey.svelte
@@ -19,6 +19,9 @@
 	$: middle_c = midi === 60;
 
 	// TODO BLOCK `pressed` -- how? as a prop or hook into the audio system?
+	// return a store for `midi`? but we want to decouple it so `PianoKey` can be controlled however
+	// or should there be a `$pressed_keys.has(key)`?
+	// $: pressed =
 </script>
 
 <button

--- a/src/lib/music/PianoKey.svelte
+++ b/src/lib/music/PianoKey.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import {createEventDispatcher} from 'svelte';
+	import {swallow} from '@feltjs/util/dom.js';
 
 	import {midi_naturals} from '$lib/music/notes';
 	import type {Midi} from '$lib/music/midi';
@@ -10,6 +11,7 @@
 	export let left_offset: number;
 	export let clickable = true;
 	export let enabled = true;
+	export let pressed = false;
 	export let highlighted = false;
 	export let emphasized = false;
 	export let show_middle_c = true;
@@ -31,11 +33,27 @@
 	class:accidental
 	class:disabled={!enabled}
 	class:clickable={clickable && enabled}
+	class:active={pressed}
 	class:highlighted
 	class:emphasized
-	on:pointerdown={enabled ? () => dispatch('press', midi) : undefined}
-	on:pointerup={enabled ? () => dispatch('release', midi) : undefined}
-	on:pointerleave={enabled ? () => dispatch('release', midi) : undefined}
+	on:mousedown={enabled
+		? (e) => {
+				swallow(e);
+				dispatch('press', midi);
+		  }
+		: undefined}
+	on:mouseup={enabled
+		? (e) => {
+				swallow(e);
+				dispatch('release', midi);
+		  }
+		: undefined}
+	on:mouseleave={enabled
+		? (e) => {
+				swallow(e);
+				dispatch('release', midi);
+		  }
+		: undefined}
 	aria-label="piano key for midi {midi}"
 	style:left="{left_offset}px"
 >
@@ -71,7 +89,8 @@
 	.clickable:hover {
 		background-color: var(--primary_color, #00bb00);
 	}
-	.clickable:active {
+	.clickable:active,
+	.clickable.active {
 		background-color: var(--primary_color_dark, #007700);
 	}
 

--- a/src/lib/music/PianoKey.svelte
+++ b/src/lib/music/PianoKey.svelte
@@ -19,11 +19,6 @@
 	$: natural = midi_naturals.has(midi);
 	$: accidental = !natural;
 	$: middle_c = midi === 60;
-
-	// TODO BLOCK `pressed` -- how? as a prop or hook into the audio system?
-	// return a store for `midi`? but we want to decouple it so `PianoKey` can be controlled however
-	// or should there be a `$pressed_keys.has(key)`?
-	// $: pressed =
 </script>
 
 <button

--- a/src/lib/music/PianoKey.svelte
+++ b/src/lib/music/PianoKey.svelte
@@ -17,6 +17,8 @@
 	$: natural = midi_naturals.has(midi);
 	$: accidental = !natural;
 	$: middle_c = midi === 60;
+
+	// TODO BLOCK `pressed` -- how? as a prop or hook into the audio system?
 </script>
 
 <button

--- a/src/routes/piano/+page.svelte
+++ b/src/routes/piano/+page.svelte
@@ -4,7 +4,7 @@
 	import MidiAccess from '$lib/audio/MidiAccess.svelte';
 	import MidiInput from '$lib/audio/MidiInput.svelte';
 	import {MIDI_MAX, MIDI_MIN, type Midi} from '$lib/music/midi';
-	import {start_playing, stop_playing} from '$lib/audio/play_note';
+	import {playing_notes, start_playing, stop_playing} from '$lib/audio/play_note';
 	import InitMidiButton from '$lib/audio/InitMidiButton.svelte';
 	import VolumeControl from '$lib/audio/VolumeControl.svelte';
 	import Header from '$routes/Header.svelte';
@@ -16,6 +16,8 @@
 
 	let midi_access: MidiAccess | undefined;
 	$: ma = midi_access?.ma;
+
+	$: pressed_keys = $playing_notes;
 
 	let clientWidth: number; // `undefined` on first render
 
@@ -45,6 +47,7 @@
 				width={clientWidth - piano_padding * 2}
 				{note_min}
 				{note_max}
+				{pressed_keys}
 				on:press={(e) => start_playing(audio_ctx, e.detail, $volume)}
 				on:release={(e) => stop_playing(e.detail)}
 			/>

--- a/src/routes/style.css
+++ b/src/routes/style.css
@@ -79,7 +79,8 @@ a:active {
 .clickable:hover {
 	transform: scale3d(var(--scale, 1.03), var(--scale, 1.03), var(--scale, 1.03)) skew(0.6deg);
 }
-.clickable:active {
+.clickable:active,
+.clickable.active {
 	transform: scale3d(var(--scale, 0.94), var(--scale, 0.94), var(--scale, 0.94));
 }
 


### PR DESCRIPTION
continuing from #3 

shows piano key state based on the audio that's playing

followup:

- figure out level variants
- animate the tonic when ready to start
- turn `level.ts` into a component and use `@preactjs/signals` with `accessors` for exported const stores
- more level defs
- show level history/stats/achievements visually on the map
- level unlocks
- create a level def with a form (and import/export json)
- show interval info on the trial?
