### PR TITLE
add data import/export

### DIFF
--- a/src/lib/audio/InitMidiButton.svelte
+++ b/src/lib/audio/InitMidiButton.svelte
@@ -14,7 +14,7 @@
 <button
 	type="button"
 	class="big"
-	on:click={() => void midi_access?.init()}
+	on:click={() => void midi_access?.request_access()}
 	{disabled}
 	title={midi_access ? ($ma ? 'MIDI is ready!' : 'connect your MIDI device') : 'loading...'}
 >

--- a/src/lib/audio/InitMidiButton.svelte
+++ b/src/lib/audio/InitMidiButton.svelte
@@ -22,8 +22,13 @@
 	on:click={async () => {
 		if (!midi_access) return;
 		request_status = 'pending';
-		await midi_access.request_access();
-		request_status = 'success';
+		try {
+			await midi_access.request_access();
+			request_status = 'success';
+		} catch (err) {
+			console.error('failed to request midi access', err);
+			request_status = 'failure';
+		}
 	}}
 	{disabled}
 	title={midi_access ? ($ma ? 'MIDI is ready!' : 'connect your MIDI device') : 'loading...'}

--- a/src/lib/audio/InitMidiButton.svelte
+++ b/src/lib/audio/InitMidiButton.svelte
@@ -14,6 +14,8 @@
 	$: disabled = !midi_access || !!$ma || request_status === 'pending';
 
 	$: midi_inputs = $ma && Array.from($ma.inputs.values());
+
+	let request_error: string | undefined;
 </script>
 
 <button
@@ -28,6 +30,7 @@
 		} catch (err) {
 			console.error('failed to request midi access', err);
 			request_status = 'failure';
+			request_error = err.message;
 		}
 	}}
 	{disabled}
@@ -45,11 +48,14 @@
 				{/each}
 			</table>
 		{:else}
-			no MIDI devices found :[
+			<span in:fade|local>no MIDI devices found :[</span>
 		{/if}
 	{:else if request_status === 'pending'}
-		<!-- fade in because it may be replaced immediately -->
 		<span in:fade|local>requesting MIDI access</span>
+	{:else if request_status === 'failure'}
+		<span in:fade|local
+			>failed to request MIDI access{#if request_error}: {request_error}{/if}</span
+		>
 	{:else}
 		init MIDI
 	{/if}

--- a/src/lib/audio/InitMidiButton.svelte
+++ b/src/lib/audio/InitMidiButton.svelte
@@ -44,7 +44,7 @@
 		{/if}
 	{:else if request_status === 'pending'}
 		<!-- fade in because it may be replaced immediately -->
-		<div in:fade|local>requesting MIDI access</div>
+		<span in:fade|local>requesting MIDI access</span>
 	{:else}
 		init MIDI
 	{/if}

--- a/src/lib/earworm/Level.svelte
+++ b/src/lib/earworm/Level.svelte
@@ -116,6 +116,7 @@
 			if (status === 'complete') {
 				start_playing(audio_ctx, e.detail.note, $volume);
 			} else {
+				// TODO should we intercept here if disabled, and just play the blip with no penalty? or should that be a param to `guess`?
 				level.guess(e.detail.note);
 			}
 		}}

--- a/src/lib/earworm/LevelDefForm.svelte
+++ b/src/lib/earworm/LevelDefForm.svelte
@@ -77,7 +77,7 @@
 		const imported = prompt('data for this level: ', serialized); // eslint-disable-line no-alert
 		if (imported) {
 			try {
-				// TODO BLOCK zod parser?
+				// TODO zod parser?
 				const parsed = JSON.parse(imported);
 				console.log(`parsed`, parsed);
 				set_level_def(parsed);

--- a/src/lib/earworm/LevelDefForm.svelte
+++ b/src/lib/earworm/LevelDefForm.svelte
@@ -69,6 +69,23 @@
 		note_min !== level_def.note_min ||
 		note_max !== level_def.note_max ||
 		intervals.toString() !== level_def.intervals.toString(); // TODO use a proper library
+
+	const import_data = () => {
+		const data = to_data();
+		const serialized = JSON.stringify(data);
+		// TODO refactor
+		const imported = prompt('data for this level: ', serialized); // eslint-disable-line no-alert
+		if (imported) {
+			try {
+				// TODO BLOCK zod parser?
+				const parsed = JSON.parse(imported);
+				console.log(`parsed`, parsed);
+				set_level_def(parsed);
+			} catch (err) {
+				console.error('failed to parse', err, imported);
+			}
+		}
+	};
 </script>
 
 <form class="level-def-form">
@@ -152,6 +169,9 @@
 		disabled={editing && !changed}
 	>
 		{#if editing}save changes to level{:else}create level{/if}
+	</button>
+	<button type="button" on:click={import_data}>
+		{#if editing}import/export data{:else}import data{/if}
 	</button>
 	{#if editing}
 		<button type="button" on:click={() => (removing = !removing)}> remove level </button>

--- a/src/lib/earworm/level_defs.ts
+++ b/src/lib/earworm/level_defs.ts
@@ -44,16 +44,18 @@ export const level_defs: LevelDef[] = [
 	{
 		name: 'major second vs major third',
 		intervals: [2, 4],
-		// TODO BLOCK variants: ['up_and_down']
+		// TODO variants, how to implement?
+		// as helper functions?
+		// `transform_to_up_and_down(level_def)`
+		// `with_up_and_down(level_def)`
+		// or as data?
+		// ['up_and_down']
 		// {up_and_down: {options}} (allows options)
 		// {type: 'up_and_down', options}} (allows multiple of each variant with options)
 		// or maybe
 		// group: 'major second vs major third'
 		// or
 		// groups: ['major second vs major third']
-		// think about:
-		// `transform_to_up_and_down(level_def)`
-		// `with_up_and_down(level_def)`
 	},
 	{
 		name: 'major second vs perfect octave up and down',

--- a/src/lib/earworm/level_defs.ts
+++ b/src/lib/earworm/level_defs.ts
@@ -53,6 +53,7 @@ export const level_defs: LevelDef[] = [
 		// groups: ['major second vs major third']
 		// think about:
 		// `transform_to_up_and_down(level_def)`
+		// `with_up_and_down(level_def)`
 	},
 	{
 		name: 'major second vs perfect octave up and down',

--- a/src/lib/earworm/level_defs.ts
+++ b/src/lib/earworm/level_defs.ts
@@ -44,7 +44,7 @@ export const level_defs: LevelDef[] = [
 	{
 		name: 'major second vs major third',
 		intervals: [2, 4],
-		// TODO variants: ['up_and_down']
+		// TODO BLOCK variants: ['up_and_down']
 		// {up_and_down: {options}} (allows options)
 		// {type: 'up_and_down', options}} (allows multiple of each variant with options)
 	},

--- a/src/lib/earworm/level_defs.ts
+++ b/src/lib/earworm/level_defs.ts
@@ -47,6 +47,12 @@ export const level_defs: LevelDef[] = [
 		// TODO BLOCK variants: ['up_and_down']
 		// {up_and_down: {options}} (allows options)
 		// {type: 'up_and_down', options}} (allows multiple of each variant with options)
+		// or maybe
+		// group: 'major second vs major third'
+		// or
+		// groups: ['major second vs major third']
+		// think about:
+		// `transform_to_up_and_down(level_def)`
 	},
 	{
 		name: 'major second vs perfect octave up and down',

--- a/src/lib/music/PianoKey.svelte
+++ b/src/lib/music/PianoKey.svelte
@@ -19,6 +19,75 @@
 	$: natural = midi_naturals.has(midi);
 	$: accidental = !natural;
 	$: middle_c = midi === 60;
+
+	// TODO BLOCK do we want to focus here or reactively to the state of notes playing? maybe take the first of `playing_notes`?
+
+	const focus_previous_button = (node: Node): void => {
+		let s: ChildNode | null | undefined = node.previousSibling;
+		// TODO hacky
+		if (!(s instanceof HTMLButtonElement)) s = s?.previousSibling;
+		if (!(s instanceof HTMLButtonElement)) s = s?.previousSibling;
+		if (s instanceof HTMLButtonElement) s.focus();
+	};
+	const focus_next_button = (node: Node): void => {
+		let s: ChildNode | null | undefined = node.nextSibling;
+		// TODO hacky
+		if (!(s instanceof HTMLButtonElement)) s = s?.nextSibling;
+		if (!(s instanceof HTMLButtonElement)) s = s?.nextSibling;
+		if (s instanceof HTMLButtonElement) s.focus();
+	};
+
+	const keydown = (
+		e: KeyboardEvent & {
+			currentTarget: EventTarget & HTMLButtonElement;
+		},
+	): void => {
+		const {key} = e;
+		switch (key) {
+			case ' ':
+			case 'Enter': {
+				swallow(e);
+				dispatch('press', midi);
+				e.currentTarget.focus();
+				break;
+			}
+			case 'ArrowLeft': {
+				if (e.currentTarget instanceof Node) {
+					console.log(
+						`((e.currentTarget as Node).nextSibling`,
+						(e.currentTarget as Node).nextSibling,
+					);
+					focus_previous_button(e.currentTarget);
+				}
+				break;
+			}
+			case 'ArrowRight': {
+				if (e.currentTarget instanceof Node) {
+					console.log(
+						`((e.currentTarget as Node).nextSibling`,
+						(e.currentTarget as Node).nextSibling,
+					);
+					focus_next_button(e.currentTarget);
+				}
+				break;
+			}
+		}
+	};
+	const keyup = (
+		e: KeyboardEvent & {
+			currentTarget: EventTarget & HTMLButtonElement;
+		},
+	): void => {
+		const {key} = e;
+		switch (key) {
+			case ' ':
+			case 'Enter': {
+				swallow(e);
+				dispatch('release', midi);
+				break;
+			}
+		}
+	};
 </script>
 
 <button
@@ -31,10 +100,13 @@
 	class:active={pressed}
 	class:highlighted
 	class:emphasized
+	on:keydown={enabled ? keydown : undefined}
+	on:keyup={enabled ? keyup : undefined}
 	on:mousedown={enabled
 		? (e) => {
 				swallow(e);
 				dispatch('press', midi);
+				e.currentTarget.focus();
 		  }
 		: undefined}
 	on:mouseup={enabled
@@ -59,6 +131,7 @@
 
 <style>
 	.piano-key {
+		/* custom */
 		--natural_width: var(--piano_natural_key_width, 60px);
 		--natural_height: var(--piano_natural_key_height, 175px);
 		--accidental_width: var(--piano_accidental_key_width, 35px);
@@ -66,12 +139,19 @@
 		--border_color: var(--piano_border_color, rgba(0, 0, 0, 0.22));
 		/* TODO scale to `piano_key_width` */
 		--emphasized_marker_width: 20px;
+		--z_index_offset: 0;
 
 		position: absolute;
 		top: 0;
 		border-radius: var(--border_radius_xs);
 		padding: 0;
 		min-height: 0;
+		z-index: var(--z_index_offset);
+	}
+
+	.piano-key:focus {
+		--z_index_offset: 1;
+		outline-width: var(--border_width_4);
 	}
 
 	.piano-key:last-child {
@@ -87,19 +167,19 @@
 	.clickable:active,
 	.clickable.active {
 		background-color: var(--primary_color_dark, #007700);
+		outline-width: var(--border_width_3);
 	}
 
 	.natural {
 		width: var(--natural_width);
 		height: var(--natural_height);
 		background-color: var(--piano_natural_key_color, #fff);
-		z-index: 1;
 	}
 	.accidental {
 		width: var(--accidental_width);
 		height: var(--accidental_height);
 		background-color: var(--piano_accidental_key_color, #333);
-		z-index: 2;
+		z-index: calc(2 + var(--z_index_offset));
 	}
 
 	.highlighted {
@@ -141,5 +221,6 @@
 		bottom: calc(var(--emphasized_marker_width) / 2);
 		width: var(--emphasized_marker_width);
 		height: var(--emphasized_marker_width);
+		user-select: none;
 	}
 </style>

--- a/src/lib/music/PianoKey.svelte
+++ b/src/lib/music/PianoKey.svelte
@@ -20,21 +20,39 @@
 	$: accidental = !natural;
 	$: middle_c = midi === 60;
 
-	// TODO BLOCK do we want to focus here or reactively to the state of notes playing? maybe take the first of `playing_notes`?
-
-	const focus_previous_button = (node: Node): void => {
+	export const query_previous_sibling = <T extends ChildNode>(
+		node: ChildNode,
+		matches: (n: ChildNode) => boolean,
+	): T | null => {
 		let s: ChildNode | null | undefined = node.previousSibling;
-		// TODO hacky
-		if (!(s instanceof HTMLButtonElement)) s = s?.previousSibling;
-		if (!(s instanceof HTMLButtonElement)) s = s?.previousSibling;
-		if (s instanceof HTMLButtonElement) s.focus();
+		while (s) {
+			if (matches(s)) return s as T;
+			s = s.previousSibling;
+		}
+		return null;
 	};
-	const focus_next_button = (node: Node): void => {
+	export const query_next_sibling = <T extends ChildNode>(
+		node: ChildNode,
+		matches: (n: ChildNode) => boolean,
+	): T | null => {
 		let s: ChildNode | null | undefined = node.nextSibling;
-		// TODO hacky
-		if (!(s instanceof HTMLButtonElement)) s = s?.nextSibling;
-		if (!(s instanceof HTMLButtonElement)) s = s?.nextSibling;
-		if (s instanceof HTMLButtonElement) s.focus();
+		while (s) {
+			if (matches(s)) return s as T;
+			s = s.nextSibling;
+		}
+		return null;
+	};
+
+	const focus_previous_button = (node: ChildNode): void => {
+		const s = query_previous_sibling<HTMLButtonElement>(
+			node,
+			(n) => n instanceof HTMLButtonElement,
+		);
+		s?.focus();
+	};
+	const focus_next_button = (node: ChildNode): void => {
+		const s = query_next_sibling<HTMLButtonElement>(node, (n) => n instanceof HTMLButtonElement);
+		s?.focus();
 	};
 
 	const keydown = (
@@ -153,6 +171,9 @@
 		--z_index_offset: 1;
 		outline-width: var(--border_width_4);
 	}
+	.piano-key:focus {
+		outline-width: var(--border_width_3);
+	}
 
 	.piano-key:last-child {
 		border-right: 1px solid var(--border_color);
@@ -167,7 +188,6 @@
 	.clickable:active,
 	.clickable.active {
 		background-color: var(--primary_color_dark, #007700);
-		outline-width: var(--border_width_3);
 	}
 
 	.natural {

--- a/src/lib/music/PianoKey.svelte
+++ b/src/lib/music/PianoKey.svelte
@@ -185,10 +185,6 @@
 	.clickable:hover {
 		background-color: var(--primary_color, #00bb00);
 	}
-	.clickable:active,
-	.clickable.active {
-		background-color: var(--primary_color_dark, #007700);
-	}
 
 	.natural {
 		width: var(--natural_width);
@@ -219,6 +215,12 @@
 	.accidental.disabled:hover,
 	.accidental.disabled:active {
 		background-color: var(--accidental_key_disabled_color, #777);
+	}
+
+	/* this is order-sensitive, makes the MIDI input override any disabled state */
+	.clickable:active,
+	.piano-key.active {
+		background-color: var(--primary_color_dark, #007700);
 	}
 
 	.emphasized::before {

--- a/src/routes/Footer.svelte
+++ b/src/routes/Footer.svelte
@@ -1,12 +1,30 @@
 <script lang="ts">
 	import Breadcrumbs from '@feltjs/felt-ui/Breadcrumbs.svelte';
+	import {page} from '$app/stores';
+	import {base} from '$app/paths';
+	import {swallow} from '@feltjs/util/dom.js';
+
+	import {goto_random_page} from '$routes/nav';
+
+	$: pathname = $page.url.pathname;
+	$: home = pathname === base + '/';
 </script>
 
 <footer>
 	<div class="panel padded-md column-sm">
 		<div>public domain</div>
 		<a href="https://github.com/ryanatkn/earworm">source code on GitHub</a>
-		<Breadcrumbs>🪱🎶</Breadcrumbs>
+		<div class="breadcrumbs-wrapper">
+			<Breadcrumbs
+				>{#if home}<button
+						class="plain-button"
+						on:click={(e) => {
+							swallow(e);
+							void goto_random_page();
+						}}>🪱🎶</button
+					>{:else}🪱🎶{/if}</Breadcrumbs
+			>
+		</div>
 	</div>
 </footer>
 
@@ -23,5 +41,8 @@
 		display: flex;
 		flex-direction: column;
 		align-items: center;
+	}
+	.breadcrumbs-wrapper {
+		font-size: var(--font_size_xl2);
 	}
 </style>

--- a/src/routes/nav.ts
+++ b/src/routes/nav.ts
@@ -1,0 +1,10 @@
+import {goto} from '$app/navigation';
+import {base} from '$app/paths';
+import {randomItem} from '@feltjs/util';
+
+const page_slugs = ['game', 'piano']; // TODO generate? import the data?
+
+export const goto_random_page = async (): Promise<void> => {
+	const path = base + '/' + randomItem(page_slugs);
+	await goto(path);
+};


### PR DESCRIPTION
continuing from #4 

- add level data import/export
- improve MIDI detection and feedback
- goto random page when clicking the breadcrumb from the home page

followup:

- cancel playing sequence at the appropriate times #8
- data persistence
- support `m` for mute
- add level variants
- animate the tonic when ready to start: https://github.com/ryanatkn/earworm/commit/308b7afb510764a2e400f9625ecb34ae362ec91d
- use `@preactjs/signals`? #7
- maybe turn `level.ts` into a component with `accessors` for exported const stores
- more level defs
- show level history/stats/achievements visually on the map
- level unlocks
- use zod schemas? #6
- later levels should not have a fixed note duration, should be player's input
- show interval info on the trial? maybe as a visualization
