### PR TITLE
add music helper to construct scales

### DIFF
--- a/src/lib/music/music.test.ts
+++ b/src/lib/music/music.test.ts
@@ -21,6 +21,15 @@ test('to_scale_notes', () => {
 		to_scale_notes(lookup_scale('major'), 4),
 		[2, 4, 5, 7, 9, 11, 12, -10, -8, -7, -5, -3, -1, -12, 14, 16, 17, 19, 21, 23, 24, -22, -20, -19, -17, -15, -13, -24], // prettier-ignore
 	);
+	assert.equal(to_scale_notes(lookup_scale('minor'), 1), [2, 3, 5, 7, 8, 10, 12]);
+	assert.equal(
+		to_scale_notes(lookup_scale('minor'), 2),
+		[2, 3, 5, 7, 8, 10, 12, -10, -9, -7, -5, -4, -2, -12],
+	);
+	assert.equal(
+		to_scale_notes(lookup_scale('minor'), 4),
+		[2, 3, 5, 7, 8, 10, 12, -10, -9, -7, -5, -4, -2, -12, 14, 15, 17, 19, 20, 22, 24, -22, -21, -19, -17, -16, -14,-24], // prettier-ignore
+	);
 });
 
 test.run();

--- a/src/lib/music/music.test.ts
+++ b/src/lib/music/music.test.ts
@@ -4,6 +4,7 @@ import * as assert from 'uvu/assert';
 import {lookup_scale, to_scale_notes} from '$lib/music/music';
 
 test('to_scale_notes', () => {
+	assert.equal(to_scale_notes(lookup_scale('pentatonic'), 1), [2, 4, 7, 9, 12]);
 	assert.equal(
 		to_scale_notes(lookup_scale('pentatonic'), 2),
 		[2, 4, 7, 9, 12, -10, -8, -5, -3, -12],
@@ -11,6 +12,10 @@ test('to_scale_notes', () => {
 	assert.equal(
 		to_scale_notes(lookup_scale('pentatonic'), 4),
 		[2, 4, 7, 9, 12, -10, -8, -5, -3, -12, 14, 16, 19, 21, 24, -22, -20, -17, -15, -24],
+	);
+	assert.equal(
+		to_scale_notes(lookup_scale('major'), 2),
+		[2, 4, 5, 7, 9, 11, 12, -10, -8, -7, -5, -3, -1, -12],
 	);
 });
 

--- a/src/lib/music/music.test.ts
+++ b/src/lib/music/music.test.ts
@@ -8,6 +8,10 @@ test('to_scale_notes', () => {
 		to_scale_notes(lookup_scale('pentatonic'), 2),
 		[2, 4, 7, 9, 12, -10, -8, -5, -3, -12],
 	);
+	assert.equal(
+		to_scale_notes(lookup_scale('pentatonic'), 4),
+		[2, 4, 7, 9, 12, -10, -8, -5, -3, -12, 14, 16, 19, 21, 24, -22, -20, -17, -15, -24],
+	);
 });
 
 test.run();

--- a/src/lib/music/music.test.ts
+++ b/src/lib/music/music.test.ts
@@ -1,0 +1,13 @@
+import {test} from 'uvu';
+import * as assert from 'uvu/assert';
+
+import {lookup_scale, to_scale_notes} from '$lib/music/music';
+
+test('to_scale_notes', () => {
+	assert.equal(
+		to_scale_notes(lookup_scale('pentatonic'), 2),
+		[2, 4, 7, 9, 12, -10, -8, -5, -3, -12],
+	);
+});
+
+test.run();

--- a/src/lib/music/music.test.ts
+++ b/src/lib/music/music.test.ts
@@ -17,6 +17,10 @@ test('to_scale_notes', () => {
 		to_scale_notes(lookup_scale('major'), 2),
 		[2, 4, 5, 7, 9, 11, 12, -10, -8, -7, -5, -3, -1, -12],
 	);
+	assert.equal(
+		to_scale_notes(lookup_scale('major'), 4),
+		[2, 4, 5, 7, 9, 11, 12, -10, -8, -7, -5, -3, -1, -12, 14, 16, 17, 19, 21, 23, 24, -22, -20, -19, -17, -15, -13, -24], // prettier-ignore
+	);
 });
 
 test.run();

--- a/src/lib/music/music.ts
+++ b/src/lib/music/music.ts
@@ -149,7 +149,7 @@ export const to_scale_notes = (scale: Scale, octaves: number): Semitones[] => {
 		for (const n of scale.notes) {
 			notes.push(n + 12 * direction * degree);
 		}
-		notes.push(12 * direction * (up ? degree + 1 : degree)); // include the octave up, but not 0
+		notes.push(12 * direction * (up ? degree + 1 : degree)); // include the octave up, but not 0 (do we want 0 tho?)
 	}
 	return notes;
 };

--- a/src/lib/music/music.ts
+++ b/src/lib/music/music.ts
@@ -112,20 +112,16 @@ export const set_enabled_notes = (
 export type ScaleName = Flavored<string, 'ScaleName'>;
 export const ScaleName = z.string().transform<ScaleName>(identity);
 
-// TODO this type is like `Semitone` with more restrictions
-export type ScaleNoteIndex = Flavored<number, 'ScaleNoteIndex'>;
-export const ScaleNoteIndex = z.number().min(1).max(11).transform<ScaleNoteIndex>(identity);
-
 export const Scale = z.object({
 	name: ScaleName,
-	notes: z.array(ScaleNoteIndex),
+	notes: z.array(Semitones),
 });
 export type Scale = z.infer<typeof Scale>;
 
 export const scales: Scale[] = [
 	{name: 'chromatic', notes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]},
-	{name: 'major (Ionian)', notes: [2, 4, 5, 7, 9, 11]},
-	{name: 'minor (Aeolian)', notes: [2, 3, 5, 7, 8, 10]},
+	{name: 'major (Ionian)', notes: [2, 4, 5, 7, 9, 11]}, // TODO maybe need a different property with the `(Ionian)`
+	{name: 'minor (Aeolian)', notes: [2, 3, 5, 7, 8, 10]}, // TODO maybe need a different property with the `(Aeolian)`
 	{name: 'Dorian', notes: [2, 3, 5, 7, 9, 10]},
 	{name: 'Phrygian', notes: [1, 3, 5, 7, 8, 10]},
 	{name: 'Lydian', notes: [2, 4, 6, 7, 9, 11]},

--- a/src/lib/music/music.ts
+++ b/src/lib/music/music.ts
@@ -81,21 +81,7 @@ export const chroma_to_hsl_string: Map<Chroma, string> = new Map(
 	chromas.map((chroma) => [chroma, hsl_to_string(...chroma_to_hsl.get(chroma)!)]),
 );
 
-export const interval_short_names = Object.freeze([
-	'P1',
-	'm2',
-	'M2',
-	'm3',
-	'M3',
-	'P4',
-	'd5',
-	'P5',
-	'm6',
-	'M6',
-	'm7',
-	'M7',
-	'P8',
-] as const);
+export const interval_short_names = Object.freeze(['P1', 'm2', 'M2', 'm3', 'M3', 'P4', 'd5', 'P5', 'm6', 'M6', 'm7', 'M7', 'P8'] as const); // prettier-ignore
 
 export type IntervalShortNames = (typeof interval_short_names)[number];
 
@@ -157,19 +143,17 @@ export const lookup_scale = (name: ScaleName): Scale => {
 	return found;
 };
 
-// TODO BLOCK name?
 export const to_scale_notes = (scale: Scale, octaves: number): Semitones[] => {
 	const notes: number[] = [];
 	for (let i = 0; i < octaves; i++) {
 		const up = i % 2 === 0;
-		const direction = up ? 1 : -1; // up, up, down, up, down, up, ...
+		const direction = up ? 1 : -1;
 		// `degree` is the offset multiplier from the base scale, so 2 is the second octave both up and down
 		const degree = up ? i / 2 : (i + 1) / 2;
 		for (const n of scale.notes) {
-			console.log(`i, n, up, direction, degree`, i, n, up, direction, degree);
 			notes.push(n + 12 * direction * degree);
 		}
-		notes.push(12 * direction * (degree || 1)); // include the octave up, but not 0
+		notes.push(12 * direction * (up ? degree + 1 : degree)); // include the octave up, but not 0
 	}
 	return notes;
 };

--- a/src/lib/music/music.ts
+++ b/src/lib/music/music.ts
@@ -120,8 +120,8 @@ export type Scale = z.infer<typeof Scale>;
 
 export const scales: Scale[] = [
 	{name: 'chromatic', notes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]},
-	{name: 'major (Ionian)', notes: [2, 4, 5, 7, 9, 11]}, // TODO maybe need a different property with the `(Ionian)`
-	{name: 'minor (Aeolian)', notes: [2, 3, 5, 7, 8, 10]}, // TODO maybe need a different property with the `(Aeolian)`
+	{name: 'major', notes: [2, 4, 5, 7, 9, 11]},
+	{name: 'minor', notes: [2, 3, 5, 7, 8, 10]},
 	{name: 'Dorian', notes: [2, 3, 5, 7, 9, 10]},
 	{name: 'Phrygian', notes: [1, 3, 5, 7, 8, 10]},
 	{name: 'Lydian', notes: [2, 4, 6, 7, 9, 11]},

--- a/src/lib/projects/default-project.ts
+++ b/src/lib/projects/default-project.ts
@@ -35,7 +35,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'one octave',
-						intervals: lookup_scale('pentatonic'),
+						intervals: lookup_scale('pentatonic').notes,
 						sequence_length: 2,
 					},
 					{
@@ -50,7 +50,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'one octave (4 notes)',
-						intervals: lookup_scale('pentatonic'),
+						intervals: lookup_scale('pentatonic').notes,
 						sequence_length: 4,
 					},
 					{
@@ -65,7 +65,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'one octave (8 notes)',
-						intervals: lookup_scale('pentatonic'),
+						intervals: lookup_scale('pentatonic').notes,
 						sequence_length: 8,
 					},
 					{
@@ -110,7 +110,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'one octave',
-						intervals: [2, 4, 5, 7, 9, 11],
+						intervals: lookup_scale('major (Ionian)').notes,
 						sequence_length: 2,
 					},
 					{
@@ -125,7 +125,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'one octave (4 notes)',
-						intervals: [2, 4, 5, 7, 9, 11],
+						intervals: lookup_scale('major (Ionian)').notes,
 						sequence_length: 4,
 					},
 					{
@@ -140,7 +140,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'one octave (8 notes)',
-						intervals: [2, 4, 5, 7, 9, 11],
+						intervals: lookup_scale('major (Ionian)').notes,
 						sequence_length: 8,
 					},
 					{

--- a/src/lib/projects/default-project.ts
+++ b/src/lib/projects/default-project.ts
@@ -120,7 +120,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'four octaves',
-						intervals: [2, 4, 5, 7, 9, 11, 12, -10, -8, -7, -5, -3, -1, -12, 14, 16, 17, 19, 21, 23, 24, -24, -22, -20, -19, -17, -15, -13], // prettier-ignore
+						intervals: to_scale_notes(lookup_scale('major'), 4),
 						sequence_length: 2,
 					},
 					{
@@ -135,7 +135,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'four octaves (4 notes)',
-						intervals: [2, 4, 5, 7, 9, 11, 12, -10, -8, -7, -5, -3, -1, -12, 14, 16, 17, 19, 21, 23, 24, -24, -22, -20, -19, -17, -15, -13], // prettier-ignore
+						intervals: to_scale_notes(lookup_scale('major'), 4),
 						sequence_length: 4,
 					},
 					{
@@ -150,7 +150,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'four octaves (8 notes)',
-						intervals: [2, 4, 5, 7, 9, 11, 12, -10, -8, -7, -5, -3, -1, -12, 14, 16, 17, 19, 21, 23, 24, -24, -22, -20, -19, -17, -15, -13], // prettier-ignore
+						intervals: to_scale_notes(lookup_scale('major'), 4),
 						sequence_length: 8,
 					},
 				].map((v) => LevelDef.parse(v)),

--- a/src/lib/projects/default-project.ts
+++ b/src/lib/projects/default-project.ts
@@ -35,7 +35,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'one octave',
-						intervals: [2, 4, 7, 9],
+						intervals: lookup_scale('pentatonic'),
 						sequence_length: 2,
 					},
 					{
@@ -50,7 +50,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'one octave (4 notes)',
-						intervals: [2, 4, 7, 9],
+						intervals: lookup_scale('pentatonic'),
 						sequence_length: 4,
 					},
 					{
@@ -65,7 +65,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'one octave (8 notes)',
-						intervals: [2, 4, 7, 9],
+						intervals: lookup_scale('pentatonic'),
 						sequence_length: 8,
 					},
 					{

--- a/src/lib/projects/default-project.ts
+++ b/src/lib/projects/default-project.ts
@@ -115,7 +115,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'two octaves',
-						intervals: [2, 4, 5, 7, 9, 11, 12, -10, -8, -7, -5, -3, -1, -12],
+						intervals: to_scale_notes(lookup_scale('major'), 2),
 						sequence_length: 2,
 					},
 					{
@@ -130,7 +130,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'two octaves (4 notes)',
-						intervals: [2, 4, 5, 7, 9, 11, 12, -10, -8, -7, -5, -3, -1, -12],
+						intervals: to_scale_notes(lookup_scale('major'), 2),
 						sequence_length: 4,
 					},
 					{
@@ -145,7 +145,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'two octaves (8 notes)',
-						intervals: [2, 4, 5, 7, 9, 11, 12, -10, -8, -7, -5, -3, -1, -12],
+						intervals: to_scale_notes(lookup_scale('major'), 2),
 						sequence_length: 8,
 					},
 					{

--- a/src/lib/projects/default-project.ts
+++ b/src/lib/projects/default-project.ts
@@ -45,7 +45,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'four octaves',
-						intervals: [2, 4, 7, 9, 12, -10, -8, -5, -3, -12, 14, 16, 19, 21, 24, -24, -22, -20, -17, -15], // prettier-ignore
+						intervals: [2, 4, 7, 9, 12, -10, -8, -5, -3, -12, 14, 16, 19, 21, 24, -22, -20, -17, -15, -24], // prettier-ignore
 						sequence_length: 2,
 					},
 					{
@@ -60,7 +60,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'four octaves (4 notes)',
-						intervals: [2, 4, 7, 9, 12, -10, -8, -5, -3, -12, 14, 16, 19, 21, 24, -24, -22, -20, -17, -15], // prettier-ignore
+						intervals: [2, 4, 7, 9, 12, -10, -8, -5, -3, -12, 14, 16, 19, 21, 24, -22, -20, -17, -15, -24], // prettier-ignore
 						sequence_length: 4,
 					},
 					{
@@ -75,7 +75,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'four octaves (8 notes)',
-						intervals: [2, 4, 7, 9, 12, -10, -8, -5, -3, -12, 14, 16, 19, 21, 24, -24, -22, -20, -17, -15], // prettier-ignore
+						intervals: [2, 4, 7, 9, 12, -10, -8, -5, -3, -12, 14, 16, 19, 21, 24, -22, -20, -17, -15, -24], // prettier-ignore
 						sequence_length: 8,
 					},
 				].map((v) => LevelDef.parse(v)),

--- a/src/lib/projects/default-project.ts
+++ b/src/lib/projects/default-project.ts
@@ -1,6 +1,7 @@
 import {RealmDef} from '$lib/earbetter/realm';
 import {LevelDef, DEFAULT_NOTE_MIN} from '$lib/earbetter/level';
 import {create_project_id, ProjectDef} from '$lib/earbetter/project';
+import {lookup_scale, to_scale_notes} from '$lib/music/music';
 
 // TODO more - modes, particular intervals, scales, chromatic, ...?
 // what's best for learning and understanding and covering the landscape?
@@ -39,7 +40,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'two octaves',
-						intervals: [2, 4, 7, 9, 12, -10, -8, -5, -3, -12],
+						intervals: to_scale_notes(lookup_scale('pentatonic'), 2),
 						sequence_length: 2,
 					},
 					{
@@ -54,7 +55,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'two octaves (4 notes)',
-						intervals: [2, 4, 7, 9, 12, -10, -8, -5, -3, -12],
+						intervals: to_scale_notes(lookup_scale('pentatonic'), 2),
 						sequence_length: 4,
 					},
 					{
@@ -69,7 +70,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'two octaves (8 notes)',
-						intervals: [2, 4, 7, 9, 12, -10, -8, -5, -3, -12],
+						intervals: to_scale_notes(lookup_scale('pentatonic'), 2),
 						sequence_length: 8,
 					},
 					{

--- a/src/lib/projects/default-project.ts
+++ b/src/lib/projects/default-project.ts
@@ -186,47 +186,47 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'one octave',
-						intervals: [2, 3, 5, 7, 8, 10],
+						intervals: to_scale_notes(lookup_scale('minor'), 1),
 						sequence_length: 2,
 					},
 					{
 						name: 'two octaves',
-						intervals: [2, 3, 5, 7, 8, 10, 12, -10, -9, -7, -5, -4, -2, -12],
+						intervals: to_scale_notes(lookup_scale('minor'), 2),
 						sequence_length: 2,
 					},
 					{
 						name: 'four octaves',
-						intervals: [2, 3, 5, 7, 8, 10, 12, -10, -9, -7, -5, -4, -2, -12, 14, 15, 17, 19, 20, 22, 24, -24, -22, -21, -19, -17, -16, -14], // prettier-ignore
+						intervals: to_scale_notes(lookup_scale('minor'), 4),
 						sequence_length: 2,
 					},
 					{
 						name: 'one octave (4 notes)',
-						intervals: [2, 3, 5, 7, 8, 10],
+						intervals: to_scale_notes(lookup_scale('minor'), 1),
 						sequence_length: 4,
 					},
 					{
 						name: 'two octaves (4 notes)',
-						intervals: [2, 3, 5, 7, 8, 10, 12, -10, -9, -7, -5, -4, -2, -12],
+						intervals: to_scale_notes(lookup_scale('minor'), 2),
 						sequence_length: 4,
 					},
 					{
 						name: 'four octaves (4 notes)',
-						intervals: [2, 3, 5, 7, 8, 10, 12, -10, -9, -7, -5, -4, -2, -12, 14, 15, 17, 19, 20, 22, 24, -24, -22, -21, -19, -17, -16, -14], // prettier-ignore
+						intervals: to_scale_notes(lookup_scale('minor'), 4),
 						sequence_length: 4,
 					},
 					{
 						name: 'one octave (8 notes)',
-						intervals: [2, 3, 5, 7, 8, 10],
+						intervals: to_scale_notes(lookup_scale('minor'), 1),
 						sequence_length: 8,
 					},
 					{
 						name: 'two octaves (8 notes)',
-						intervals: [2, 3, 5, 7, 8, 10, 12, -10, -9, -7, -5, -4, -2, -12],
+						intervals: to_scale_notes(lookup_scale('minor'), 2),
 						sequence_length: 8,
 					},
 					{
 						name: 'four octaves (8 notes)',
-						intervals: [2, 3, 5, 7, 8, 10, 12, -10, -9, -7, -5, -4, -2, -12, 14, 15, 17, 19, 20, 22, 24, -24, -22, -21, -19, -17, -16, -14], // prettier-ignore
+						intervals: to_scale_notes(lookup_scale('minor'), 4),
 						sequence_length: 8,
 					},
 				].map((v) => LevelDef.parse(v)),

--- a/src/lib/projects/default-project.ts
+++ b/src/lib/projects/default-project.ts
@@ -45,7 +45,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'four octaves',
-						intervals: [2, 4, 7, 9, 12, -10, -8, -5, -3, -12, 14, 16, 19, 21, 24, -22, -20, -17, -15, -24], // prettier-ignore
+						intervals: to_scale_notes(lookup_scale('pentatonic'), 4),
 						sequence_length: 2,
 					},
 					{
@@ -60,7 +60,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'four octaves (4 notes)',
-						intervals: [2, 4, 7, 9, 12, -10, -8, -5, -3, -12, 14, 16, 19, 21, 24, -22, -20, -17, -15, -24], // prettier-ignore
+						intervals: to_scale_notes(lookup_scale('pentatonic'), 4),
 						sequence_length: 4,
 					},
 					{
@@ -75,7 +75,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'four octaves (8 notes)',
-						intervals: [2, 4, 7, 9, 12, -10, -8, -5, -3, -12, 14, 16, 19, 21, 24, -22, -20, -17, -15, -24], // prettier-ignore
+						intervals: to_scale_notes(lookup_scale('pentatonic'), 4),
 						sequence_length: 8,
 					},
 				].map((v) => LevelDef.parse(v)),

--- a/src/lib/projects/default-project.ts
+++ b/src/lib/projects/default-project.ts
@@ -81,7 +81,7 @@ const def = (): ProjectDef =>
 				].map((v) => LevelDef.parse(v)),
 			},
 			{
-				name: 'major scale (Ionian)',
+				name: 'major scale',
 				level_defs: [
 					{
 						name: 'major second vs major third',
@@ -110,7 +110,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'one octave',
-						intervals: lookup_scale('major (Ionian)').notes,
+						intervals: lookup_scale('major').notes,
 						sequence_length: 2,
 					},
 					{
@@ -125,7 +125,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'one octave (4 notes)',
-						intervals: lookup_scale('major (Ionian)').notes,
+						intervals: lookup_scale('major').notes,
 						sequence_length: 4,
 					},
 					{
@@ -140,7 +140,7 @@ const def = (): ProjectDef =>
 					},
 					{
 						name: 'one octave (8 notes)',
-						intervals: lookup_scale('major (Ionian)').notes,
+						intervals: lookup_scale('major').notes,
 						sequence_length: 8,
 					},
 					{
@@ -156,7 +156,7 @@ const def = (): ProjectDef =>
 				].map((v) => LevelDef.parse(v)),
 			},
 			{
-				name: 'minor scale (Aeolian)',
+				name: 'minor scale',
 				level_defs: [
 					// TODO maybe arrange these by difficulty?
 					{

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -132,7 +132,7 @@
 		<section>
 			<SiteMap />
 		</section>
-		<section class="centered">
+		<section class="centered column-sm">
 			<h2 class="section-title">data</h2>
 			<button on:click={() => (deleting = !deleting)}> clear saved data </button>
 			{#if deleting}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -148,6 +148,16 @@
 				</div>
 			{/if}
 		</section>
+		<section class="centered markup column-sm">
+			<h2 class="section-title">privacy</h2>
+			<p class="padded-md">
+				this website collects no data - the only server it talks to is <a
+					href="https://pages.github.com/">GitHub Pages</a
+				>
+				to serve static files, see
+				<a href="https://github.com/ryanatkn/earbetter">the source code</a> for more
+			</p>
+		</section>
 		<Footer flush={true} />
 	</Dialog>
 {/if}


### PR DESCRIPTION
adds `to_scale_notes` to construct scales programmatically, replacing the default project data using the new helper