### PR TITLE
convert to Svelte 5 runes from Preact Signals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.1",
       "license": "Unlicense",
       "devDependencies": {
-        "@preact/signals-core": "^1.6.1",
         "@ryanatkn/belt": "^0.24.4",
         "@ryanatkn/eslint-config": "^0.4.0",
         "@ryanatkn/fuz": "^0.108.3",
@@ -316,17 +315,6 @@
       "version": "1.0.0-next.25",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@preact/signals-core": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.6.1.tgz",
-      "integrity": "sha512-KXEEmJoKDlo0Igju/cj9YvKIgyaWFDgnprShQjzimUd5VynAAdTWMshawEOjUVeKbsI0aR58V6WOQp+DNcKApw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
-      }
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.14.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "node": ">=20.12"
   },
   "devDependencies": {
-    "@preact/signals-core": "^1.6.1",
     "@ryanatkn/belt": "^0.24.4",
     "@ryanatkn/eslint-config": "^0.4.0",
     "@ryanatkn/fuz": "^0.108.3",

--- a/src/lib/Init_Midi_Button.svelte
+++ b/src/lib/Init_Midi_Button.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import type {Async_Status} from '@ryanatkn/belt/async.js';
 	import {fade} from 'svelte/transition';
-	import type {Signal} from '@preact/signals-core';
 
 	import type {MIDIAccess} from '$lib/WebMIDI.js';
 	import {reset_midi_access, request_access as default_request_access} from '$lib/midi_access.js';

--- a/src/lib/Init_Midi_Button.svelte
+++ b/src/lib/Init_Midi_Button.svelte
@@ -6,21 +6,19 @@
 	import {reset_midi_access, request_access as default_request_access} from '$lib/midi_access.js';
 
 	interface Props {
-		midi_state: {midi_access: Signal<MIDIAccess | null>};
-		request_access?: (state: {
-			midi_access: Signal<MIDIAccess | null>;
-		}) => Promise<MIDIAccess | null>;
+		midi_state: {midi_access: MIDIAccess | null};
+		request_access?: (state: {midi_access: MIDIAccess | null}) => Promise<MIDIAccess | null>;
 	}
 
 	const {midi_state, request_access = default_request_access}: Props = $props();
 
 	// TODO move MIDI initialization to some other action, like the button to start a level
 
-	const {midi_access} = $derived(midi_state);
-
 	let request_status: Async_Status = $state('initial');
 
-	const midi_inputs = $derived($midi_access && Array.from($midi_access.inputs.values()));
+	const midi_inputs = $derived(
+		midi_state.midi_access && Array.from(midi_state.midi_access.inputs.values()),
+	);
 	const midi_input_count = $derived(midi_inputs?.length ?? 0);
 
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
@@ -28,7 +26,7 @@
 
 	let request_error: string | undefined = $state();
 
-	$inspect('$midi_access', $midi_access);
+	$inspect('midi_state.midi_access', midi_state.midi_access);
 </script>
 
 <button
@@ -49,9 +47,9 @@
 		}
 	}}
 	{disabled}
-	title={$midi_access ? 'MIDI is ready!' : 'connect your MIDI device [c]'}
+	title={midi_state.midi_access ? 'MIDI is ready!' : 'connect your MIDI device [c]'}
 >
-	{#if $midi_access}
+	{#if midi_state.midi_access}
 		{#if midi_inputs?.length}
 			<div>
 				<div>MIDI devices</div>

--- a/src/lib/Instrument_Control.svelte
+++ b/src/lib/Instrument_Control.svelte
@@ -7,7 +7,7 @@
 
 	let {instrument = $bindable()}: Props = $props();
 
-	// TODO BLOCK event callback or $bindable
+	// TODO BLOCK @multiple event callback or $bindable
 </script>
 
 <div class="mb_lg">

--- a/src/lib/Instrument_Control.svelte
+++ b/src/lib/Instrument_Control.svelte
@@ -8,14 +8,12 @@
 	let {instrument = $bindable()}: Props = $props();
 
 	// TODO BLOCK event callback or $bindable
-	const input = (e: any) => (instrument = e.currentTarget.value);
 </script>
 
 <div class="mb_lg">
 	<label class="text_align_center">
 		<div class="title">instrument</div>
-		<!-- TODO use `bind:value={$instrument}` when this PR is in: https://github.com/preactjs/signals/pull/325  -->
-		<select bind:value={instrument} oninput={input}>
+		<select bind:value={instrument}>
 			{#each instruments as t}
 				<option value={t}>{t}</option>
 			{/each}

--- a/src/lib/Instrument_Control.svelte
+++ b/src/lib/Instrument_Control.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import type {Signal} from '@preact/signals-core';
-
 	import {instruments, type Instrument} from '$lib/audio_helpers.js';
 
 	interface Props {

--- a/src/lib/Instrument_Control.svelte
+++ b/src/lib/Instrument_Control.svelte
@@ -2,20 +2,20 @@
 	import {instruments, type Instrument} from '$lib/audio_helpers.js';
 
 	interface Props {
-		instrument: Signal<Instrument>;
+		instrument: Instrument;
 	}
 
-	const {instrument}: Props = $props();
+	let {instrument = $bindable()}: Props = $props();
 
 	// TODO BLOCK event callback or $bindable
-	const input = (e: any) => (instrument.value = e.currentTarget.value);
+	const input = (e: any) => (instrument = e.currentTarget.value);
 </script>
 
 <div class="mb_lg">
 	<label class="text_align_center">
 		<div class="title">instrument</div>
 		<!-- TODO use `bind:value={$instrument}` when this PR is in: https://github.com/preactjs/signals/pull/325  -->
-		<select value={$instrument} oninput={input}>
+		<select bind:value={instrument} oninput={input}>
 			{#each instruments as t}
 				<option value={t}>{t}</option>
 			{/each}

--- a/src/lib/Instrument_Control.svelte
+++ b/src/lib/Instrument_Control.svelte
@@ -9,7 +9,7 @@
 
 	const {instrument}: Props = $props();
 
-	// TODO remove after signals adds `set` so we can use two-way binding
+	// TODO BLOCK event callback or $bindable
 	const input = (e: any) => (instrument.value = e.currentTarget.value);
 </script>
 

--- a/src/lib/Instrument_Control.svelte
+++ b/src/lib/Instrument_Control.svelte
@@ -7,7 +7,7 @@
 
 	let {instrument = $bindable()}: Props = $props();
 
-	// TODO BLOCK @multiple event callback or $bindable
+	// TODO @multiple event callback or $bindable
 </script>
 
 <div class="mb_lg">

--- a/src/lib/Intervals_Input.svelte
+++ b/src/lib/Intervals_Input.svelte
@@ -23,12 +23,14 @@
 	// TODO @multiple review this effect to try to remove it
 	$effect(() => {
 		updated_scale = scale;
+		// TODO probably `onscale?.(updated_scale);`
 	});
 	$effect(() => {
 		updated_octaves = octaves;
+		// TODO probably `onoctaves?.(updated_octaves);`
 	});
 	// TODO @multiple review this effect to try to remove it
-	// TODO hacky, could use oninput handlers but
+	// TODO (look above) hacky, could use oninput handlers but
 	// the scale select needs to wait a tick to get `updated_scale`,
 	// unlike the octave range input, maybe a bug?
 	$effect(() => {

--- a/src/lib/Intervals_Input.svelte
+++ b/src/lib/Intervals_Input.svelte
@@ -20,13 +20,14 @@
 	// TODO visualize the intervals with a piano
 	const intervals: Intervals = $derived(to_scale_notes(updated_scale, updated_octaves));
 
-	// TODO hacky
+	// TODO @multiple review this effect to try to remove it
 	$effect(() => {
 		updated_scale = scale;
 	});
 	$effect(() => {
 		updated_octaves = octaves;
 	});
+	// TODO @multiple review this effect to try to remove it
 	// TODO hacky, could use oninput handlers but
 	// the scale select needs to wait a tick to get `updated_scale`,
 	// unlike the octave range input, maybe a bug?

--- a/src/lib/Midi_Input.svelte
+++ b/src/lib/Midi_Input.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import {onDestroy} from 'svelte';
-	import type {Signal} from '@preact/signals-core';
 
 	import {type MIDIMessageEvent, MIDICommand, type MIDIAccess} from '$lib/WebMIDI.js';
 	import {parse_midi_message} from '$lib/midi_helpers.js';

--- a/src/lib/Midi_Input.svelte
+++ b/src/lib/Midi_Input.svelte
@@ -8,7 +8,7 @@
 	const log = console.log.bind(console);
 
 	interface Props {
-		midi_access: Signal<MIDIAccess | null>;
+		midi_access: MIDIAccess | null;
 		onnotestart?: (note: Midi, velocity: number) => void;
 		onnotestop?: (note: Midi, velocity: number) => void;
 		onpadstart?: (note: Midi, velocity: number) => void;
@@ -74,6 +74,7 @@
 		}
 	};
 
+	// TODO clean up
 	const unsubscribers: Array<() => void> = [];
 	const unsubscribe = (): void => {
 		for (const u of unsubscribers) u();
@@ -92,5 +93,5 @@
 		}
 	};
 
-	$effect(() => subscribe($midi_access));
+	$effect(() => subscribe(midi_access));
 </script>

--- a/src/lib/Midi_Range_Control.svelte
+++ b/src/lib/Midi_Range_Control.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import Alert from '@ryanatkn/fuz/Alert.svelte';
 	import {slide} from 'svelte/transition';
-	import type {Signal} from '@preact/signals-core';
 
 	import {midi_names, MIDI_MAX, MIDI_MIN, type Midi} from '$lib/music.js';
 

--- a/src/lib/Midi_Range_Control.svelte
+++ b/src/lib/Midi_Range_Control.svelte
@@ -5,29 +5,29 @@
 	import {midi_names, MIDI_MAX, MIDI_MIN, type Midi} from '$lib/music.js';
 
 	interface Props {
-		min_note: Signal<Midi>;
-		max_note: Signal<Midi>;
+		min_note: Midi;
+		max_note: Midi;
 	}
 
-	const {min_note, max_note}: Props = $props();
+	let {min_note = $bindable(), max_note = $bindable()}: Props = $props();
 
 	const error_message = $derived(
-		$min_note > $max_note ? 'note min cannot be larger than the max' : false,
+		min_note > max_note ? 'note min cannot be larger than the max' : false,
 	);
 
-	// TODO remove and use `bind:` once Signals support it
-	const input_min_note = (e: any) => (min_note.value = Number(e.currentTarget.value));
-	const input_max_note = (e: any) => (max_note.value = Number(e.currentTarget.value));
+	// TODO @multiple see about using `bind:` below if the types are correct
+	const input_min_note = (e: any) => (min_note = Number(e.currentTarget.value));
+	const input_max_note = (e: any) => (max_note = Number(e.currentTarget.value));
 </script>
 
 <div class="midi-range-control" class:error={!!error_message}>
 	<div class="box row">
 		<label class="text_align_center">
 			<div class="title">lowest note</div>
-			<div>{midi_names[$min_note]}</div>
+			<div>{midi_names[min_note]}</div>
 			<input
 				type="range"
-				value={$min_note}
+				value={min_note}
 				oninput={input_min_note}
 				step={1}
 				min={MIDI_MIN}
@@ -35,7 +35,7 @@
 			/>
 			<input
 				type="number"
-				value={$min_note}
+				value={min_note}
 				oninput={input_min_note}
 				step={1}
 				min={MIDI_MIN}
@@ -44,10 +44,10 @@
 		</label>
 		<label class="text_align_center">
 			<div class="title">highest note</div>
-			<div>{midi_names[$max_note]}</div>
+			<div>{midi_names[max_note]}</div>
 			<input
 				type="range"
-				value={$max_note}
+				value={max_note}
 				oninput={input_max_note}
 				step={1}
 				min={MIDI_MIN}
@@ -55,7 +55,7 @@
 			/>
 			<input
 				type="number"
-				value={$max_note}
+				value={max_note}
 				oninput={input_max_note}
 				step={1}
 				min={MIDI_MIN}

--- a/src/lib/Notes_Input.svelte
+++ b/src/lib/Notes_Input.svelte
@@ -172,7 +172,7 @@
 	</section>
 	<form class="width_sm panel p_md">
 		<fieldset>
-			<Instrument_Control instrument={audio_state.instrument} />
+			<Instrument_Control bind:instrument={audio_state.instrument} />
 			<Volume_Control bind:volume={audio_state.volume} />
 		</fieldset>
 		<fieldset>

--- a/src/lib/Notes_Input.svelte
+++ b/src/lib/Notes_Input.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import {plural} from '@ryanatkn/belt/string.js';
-	import {Signal} from '@preact/signals-core';
 
 	import Piano from '$lib/Piano.svelte';
 	import {get_audio_context} from '$lib/audio_context.js';

--- a/src/lib/Notes_Input.svelte
+++ b/src/lib/Notes_Input.svelte
@@ -25,10 +25,10 @@
 
 	interface Props {
 		audio_state: {
-			volume: Signal<Volume>;
-			instrument: Signal<Instrument>;
-			playing_notes: Signal<Set<Midi>>;
-			midi_access: Signal<MIDIAccess | null>;
+			volume: Volume;
+			instrument: Instrument;
+			playing_notes: Set<Midi>;
+			midi_access: MIDIAccess | null;
 		};
 		notes: Set<Midi>;
 		min_note: Midi;
@@ -37,8 +37,6 @@
 	}
 
 	const {audio_state, notes, min_note, max_note, oninput}: Props = $props();
-
-	const {volume, instrument, playing_notes, midi_access} = $derived(audio_state);
 
 	// TODO @multiple set reactivity - refactor these collections to use `svelte/reactivity` sets instead of cloning, upstream and downstream where appropriate
 
@@ -84,7 +82,13 @@
 	const piano_padding = 20;
 
 	const play = (note: Midi, velocity: number | null = null): void => {
-		start_playing(audio_state, ac(), note, with_velocity($volume, velocity), $instrument);
+		start_playing(
+			audio_state,
+			ac(),
+			note,
+			with_velocity(audio_state.volume, velocity),
+			audio_state.instrument,
+		);
 	};
 
 	const toggle_scale = (scale: Scale): void => {
@@ -112,7 +116,7 @@
 <svelte:window bind:innerWidth />
 
 <Midi_Input
-	{midi_access}
+	midi_access={audio_state.midi_access}
 	onnotestart={(note, velocity) => play(note, velocity)}
 	onnotestop={(note) => stop_playing(note)}
 />
@@ -127,7 +131,7 @@
 				{min_note}
 				{max_note}
 				max_height={300}
-				pressed_keys={$playing_notes}
+				pressed_keys={audio_state.playing_notes}
 				highlighted_keys={current_notes}
 				middle_c_label
 				allow_sticking
@@ -168,8 +172,8 @@
 	</section>
 	<form class="width_sm panel p_md">
 		<fieldset>
-			<Instrument_Control {instrument} />
-			<Volume_Control {volume} />
+			<Instrument_Control instrument={audio_state.instrument} />
+			<Volume_Control bind:volume={audio_state.volume} />
 		</fieldset>
 		<fieldset>
 			<Init_Midi_Button midi_state={audio_state} />

--- a/src/lib/Select_Notes_Control.svelte
+++ b/src/lib/Select_Notes_Control.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import type {Signal} from '@preact/signals-core';
-
 	import {
 		scales,
 		type Scale,

--- a/src/lib/Select_Notes_Control.svelte
+++ b/src/lib/Select_Notes_Control.svelte
@@ -19,6 +19,7 @@
 
 	const {scale, key}: Props = $props();
 
+	// TODO BLOCK event callback or $bindable here and below
 	const input_key = (e: Event & {currentTarget: HTMLSelectElement}) =>
 		(key.value = e.currentTarget.value as Pitch_Class);
 </script>

--- a/src/lib/Select_Notes_Control.svelte
+++ b/src/lib/Select_Notes_Control.svelte
@@ -19,7 +19,7 @@
 
 	$inspect('scale', scale);
 
-	// TODO BLOCK @multiple event callback or $bindable here and below
+	// TODO @multiple event callback or $bindable here and below
 	const input_key = (e: Event & {currentTarget: HTMLSelectElement}) =>
 		(scale = lookup_scale(e.currentTarget.value));
 </script>

--- a/src/lib/Select_Notes_Control.svelte
+++ b/src/lib/Select_Notes_Control.svelte
@@ -5,36 +5,33 @@
 		pitch_classes,
 		pitch_class_aliases,
 		type Pitch_Class,
-		lookup_scale,
 	} from '$lib/music.js';
 
 	// TODO @multiple naming convention between `Intervals_Input`/`Notes_Input`/`Select_Notes_Control`?
 
 	interface Props {
-		scale: Signal<Scale>;
-		key: Signal<Pitch_Class>;
+		scale: Scale;
+		key: Pitch_Class;
 	}
 
-	const {scale, key}: Props = $props();
+	let {scale = $bindable(), key = $bindable()}: Props = $props();
 
 	// TODO BLOCK event callback or $bindable here and below
 	const input_key = (e: Event & {currentTarget: HTMLSelectElement}) =>
-		(key.value = e.currentTarget.value as Pitch_Class);
+		(key = e.currentTarget.value as Pitch_Class);
 </script>
 
 <label class="text_align_center">
 	<div class="title">scale</div>
-	<!-- TODO use `bind:value={$scale}` when this PR is in: https://github.com/preactjs/signals/pull/325  -->
-	<select value={$scale.name} onchange={(e) => (scale.value = lookup_scale(e.currentTarget.value))}>
+	<select bind:value={scale}>
 		{#each scales as s (s)}
-			<option value={s.name}>{s.name}</option>
+			<option value={s}>{s.name}</option>
 		{/each}
 	</select>
 </label>
 <label class="text_align_center">
 	<div class="title">key</div>
-	<!-- TODO use `bind:value={$key}` when this PR is in: https://github.com/preactjs/signals/pull/325  -->
-	<select value={$key} oninput={input_key}>
+	<select bind:value={key} oninput={input_key}>
 		{#each pitch_classes as p (p)}
 			<option value={p}>
 				{p}{#if p in pitch_class_aliases}/{pitch_class_aliases[p]}{/if}

--- a/src/lib/Select_Notes_Control.svelte
+++ b/src/lib/Select_Notes_Control.svelte
@@ -16,7 +16,7 @@
 
 	let {scale = $bindable(), key = $bindable()}: Props = $props();
 
-	// TODO BLOCK event callback or $bindable here and below
+	// TODO BLOCK @multiple event callback or $bindable here and below
 	const input_key = (e: Event & {currentTarget: HTMLSelectElement}) =>
 		(key = e.currentTarget.value as Pitch_Class);
 </script>

--- a/src/lib/Select_Notes_Control.svelte
+++ b/src/lib/Select_Notes_Control.svelte
@@ -5,6 +5,7 @@
 		pitch_classes,
 		pitch_class_aliases,
 		type Pitch_Class,
+		lookup_scale,
 	} from '$lib/music.js';
 
 	// TODO @multiple naming convention between `Intervals_Input`/`Notes_Input`/`Select_Notes_Control`?
@@ -16,22 +17,25 @@
 
 	let {scale = $bindable(), key = $bindable()}: Props = $props();
 
+	$inspect('scale', scale);
+
 	// TODO BLOCK @multiple event callback or $bindable here and below
 	const input_key = (e: Event & {currentTarget: HTMLSelectElement}) =>
-		(key = e.currentTarget.value as Pitch_Class);
+		(scale = lookup_scale(e.currentTarget.value));
 </script>
 
 <label class="text_align_center">
 	<div class="title">scale</div>
-	<select bind:value={scale}>
+	<!-- TODO bind the objects not the names to simplify -->
+	<select value={scale.name} oninput={input_key}>
 		{#each scales as s (s)}
-			<option value={s}>{s.name}</option>
+			<option value={s.name}>{s.name}</option>
 		{/each}
 	</select>
 </label>
 <label class="text_align_center">
 	<div class="title">key</div>
-	<select bind:value={key} oninput={input_key}>
+	<select bind:value={key}>
 		{#each pitch_classes as p (p)}
 			<option value={p}>
 				{p}{#if p in pitch_class_aliases}/{pitch_class_aliases[p]}{/if}

--- a/src/lib/Volume_Control.svelte
+++ b/src/lib/Volume_Control.svelte
@@ -7,6 +7,8 @@
 
 	// TODO add an `oninput` callback unless the `bind` restriction is lifted
 	let {volume = $bindable(DEFAULT_VOLUME)}: Props = $props();
+
+	// TODO see about using `bind:` below if the types are correct
 </script>
 
 <label class="text_align_center">

--- a/src/lib/Volume_Control.svelte
+++ b/src/lib/Volume_Control.svelte
@@ -9,7 +9,7 @@
 
 	const {volume}: Props = $props();
 
-	// TODO use bind:value when signals adds `set`
+	// TODO BLOCK event callback or $bindable
 </script>
 
 <label class="text_align_center">

--- a/src/lib/Volume_Control.svelte
+++ b/src/lib/Volume_Control.svelte
@@ -1,31 +1,30 @@
 <script lang="ts">
-	import type {Volume} from '$lib/audio_helpers.js';
+	import {DEFAULT_VOLUME, type Volume} from '$lib/audio_helpers.js';
 
 	interface Props {
-		volume: Signal<Volume>;
+		volume: Volume;
 	}
 
-	const {volume}: Props = $props();
-
-	// TODO BLOCK event callback or $bindable
+	// TODO add an `oninput` callback unless the `bind` restriction is lifted
+	let {volume = $bindable(DEFAULT_VOLUME)}: Props = $props();
 </script>
 
 <label class="text_align_center">
 	<div class="title">volume</div>
 	<input
 		type="number"
-		oninput={(e) => (volume.value = Number(e.currentTarget.value))}
+		oninput={(e) => (volume = Number(e.currentTarget.value))}
 		step={0.01}
 		min={0}
 		max={1}
-		value={$volume}
+		value={volume}
 	/>
 	<input
 		type="range"
-		oninput={(e) => (volume.value = Number(e.currentTarget.value))}
+		oninput={(e) => (volume = Number(e.currentTarget.value))}
 		step={0.01}
 		min={0}
 		max={1}
-		value={$volume}
+		value={volume}
 	/>
 </label>

--- a/src/lib/Volume_Control.svelte
+++ b/src/lib/Volume_Control.svelte
@@ -8,7 +8,7 @@
 	// TODO add an `oninput` callback unless the `bind` restriction is lifted
 	let {volume = $bindable(DEFAULT_VOLUME)}: Props = $props();
 
-	// TODO see about using `bind:` below if the types are correct
+	// TODO @multiple see about using `bind:` below if the types are correct
 </script>
 
 <label class="text_align_center">

--- a/src/lib/Volume_Control.svelte
+++ b/src/lib/Volume_Control.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import type {Signal} from '@preact/signals-core';
-
 	import type {Volume} from '$lib/audio_helpers.js';
 
 	interface Props {

--- a/src/lib/audio_helpers.ts
+++ b/src/lib/audio_helpers.ts
@@ -25,7 +25,7 @@ export const adjust_volume = (
 ): void => {
 	// TODO awkward try/catch, but idk about `safeParse`
 	try {
-		state.volume = Volume.parse(state.volume.peek() + amount * multiplier);
+		state.volume = Volume.parse(state.volume + amount * multiplier);
 	} catch (_err) {}
 };
 

--- a/src/lib/audio_helpers.ts
+++ b/src/lib/audio_helpers.ts
@@ -1,4 +1,3 @@
-import type {Signal} from '@preact/signals-core';
 import {z} from 'zod';
 import type {Flavored} from '@ryanatkn/belt/types.js';
 import {round} from '@ryanatkn/belt/maths.js';

--- a/src/lib/audio_helpers.ts
+++ b/src/lib/audio_helpers.ts
@@ -19,13 +19,13 @@ export const with_velocity = (volume: Volume, velocity: number | null | undefine
 	Math.sqrt(velocity ?? DEFAULT_VELOCITY) * volume;
 
 export const adjust_volume = (
-	state: {volume: Signal<Volume>},
+	state: {volume: Volume},
 	multiplier = 1,
 	amount = DEFAULT_VOLUME_INCREMENT,
 ): void => {
 	// TODO awkward try/catch, but idk about `safeParse`
 	try {
-		state.volume.value = Volume.parse(state.volume.peek() + amount * multiplier);
+		state.volume = Volume.parse(state.volume.peek() + amount * multiplier);
 	} catch (_err) {}
 };
 

--- a/src/lib/earbetter/Level_Form.svelte
+++ b/src/lib/earbetter/Level_Form.svelte
@@ -3,7 +3,7 @@
 	import Dialog from '@ryanatkn/fuz/Dialog.svelte';
 	import Alert from '@ryanatkn/fuz/Alert.svelte';
 
-	import {create_level_id, Level_Data, type Level_Id} from '$lib/earbetter/level.js';
+	import {create_level_id, Level_Data, type Level_Id} from '$lib/earbetter/level.svelte.js';
 	import {
 		parse_intervals,
 		serialize_intervals,
@@ -20,7 +20,7 @@
 	import Notes_Input from '$lib/Notes_Input.svelte';
 	import Piano from '$lib/Piano.svelte';
 	import Copy_To_Clipboard from '$lib/earbetter/Copy_To_Clipboard.svelte';
-	import {get_app} from '$lib/earbetter/app.js';
+	import {get_app} from '$lib/earbetter/app.svelte.js';
 
 	interface Props {
 		level_data: Level_Data;

--- a/src/lib/earbetter/Level_Form.svelte
+++ b/src/lib/earbetter/Level_Form.svelte
@@ -72,7 +72,7 @@
 			max_note: updated_max_note,
 		});
 
-	// TODO review this effect to try to remove it
+	// TODO @multiple review this effect to try to remove it
 	$effect(() => {
 		updated_name = level_data.name;
 		updated_intervals = level_data.intervals;
@@ -101,7 +101,7 @@
 	let updated = $state('');
 	const changed_serialized = $derived(serialized !== updated);
 	let parse_error_message = $state('');
-	// TODO review this effect to try to remove it
+	// TODO @multiple review this effect to try to remove it
 	$effect(() => {
 		level_data;
 		parse_error_message = '';

--- a/src/lib/earbetter/Level_Map.svelte
+++ b/src/lib/earbetter/Level_Map.svelte
@@ -73,7 +73,7 @@
 						<h2 class="my_0">controls</h2>
 					</header>
 					<Controls_Instructions />
-					<Volume_Control volume={app.volume} />
+					<Volume_Control bind:volume={app.volume} />
 					<Instrument_Control instrument={app.instrument} />
 					<aside>Earbetter supports MIDI devices like piano keyboards, connect and click:</aside>
 					<Init_Midi_Button midi_state={app} />

--- a/src/lib/earbetter/Level_Map.svelte
+++ b/src/lib/earbetter/Level_Map.svelte
@@ -74,7 +74,7 @@
 					</header>
 					<Controls_Instructions />
 					<Volume_Control bind:volume={app.volume} />
-					<Instrument_Control instrument={app.instrument} />
+					<Instrument_Control bind:instrument={app.instrument} />
 					<aside>Earbetter supports MIDI devices like piano keyboards, connect and click:</aside>
 					<Init_Midi_Button midi_state={app} />
 				</div>

--- a/src/lib/earbetter/Level_Map.svelte
+++ b/src/lib/earbetter/Level_Map.svelte
@@ -25,21 +25,6 @@
 	const {app}: Props = $props();
 
 	const {
-		volume,
-		instrument,
-		midi_access,
-		project_datas: projects,
-		editing_project,
-		editing_project_data,
-		selected_project_data,
-		realms,
-		editing_realm,
-		editing_realm_data,
-		levels,
-		editing_level,
-		draft_level_data,
-		selected_realm_id,
-		show_trainer_help,
 		toggle_trainer_help,
 		play_level,
 		edit_level,
@@ -53,31 +38,31 @@
 	(window as any).ac = ac;
 
 	// TODO review the draft/editing data properties of `app`, some inconsistencies between levels/realms/projects
-	const level_data = $derived($draft_level_data ?? Level_Data.parse({}));
+	const level_data = $derived(app.draft_level_data ?? Level_Data.parse({}));
 
-	const editing = $derived($levels ? $levels.some((d) => d.id === level_data.id) : false);
+	const editing = $derived(app.levels ? app.levels.some((d) => d.id === level_data.id) : false);
 
-	const no_realms = $derived(!$realms?.length);
+	const no_realms = $derived(!app.realms?.length);
 </script>
 
 <Midi_Input
-	{midi_access}
+	midi_access={app.midi_access}
 	onnotestart={(note, velocity) => {
-		start_playing(app, ac(), note, with_velocity($volume, velocity), $instrument);
+		start_playing(app, ac(), note, with_velocity(app.volume, velocity), app.instrument);
 	}}
 	onnotestop={(note) => {
 		stop_playing(note);
 	}}
 />
 <div class="map">
-	{#if $projects.length}
+	{#if app.project_datas.length}
 		<div class="width_sm">
-			{#if $selected_project_data}
+			{#if app.selected_project_data}
 				<section class="card" transition:slide>
 					<Projects {app} />
 				</section>
 			{/if}
-			{#if ($editing_project && $editing_project_data) ?? !$selected_project_data}
+			{#if (app.editing_project && app.editing_project_data) ?? !app.selected_project_data}
 				<section class="card" transition:slide>
 					<Project_Editor {app} />
 				</section>
@@ -88,8 +73,8 @@
 						<h2 class="my_0">controls</h2>
 					</header>
 					<Controls_Instructions />
-					<Volume_Control {volume} />
-					<Instrument_Control {instrument} />
+					<Volume_Control volume={app.volume} />
+					<Instrument_Control instrument={app.instrument} />
 					<aside>Earbetter supports MIDI devices like piano keyboards, connect and click:</aside>
 					<Init_Midi_Button midi_state={app} />
 				</div>
@@ -97,7 +82,7 @@
 		</div>
 	{/if}
 	<div class="width_sm">
-		{#if $show_trainer_help}
+		{#if app.show_trainer_help}
 			<section class="card" transition:slide>
 				<div class="panel p_md">
 					<p>
@@ -130,20 +115,20 @@
 		<section class="card">
 			<Realms {app} />
 		</section>
-		{#if ($editing_realm && $editing_realm_data) ?? no_realms}
+		{#if (app.editing_realm && app.editing_realm_data) ?? no_realms}
 			<section class="card" transition:slide>
 				<Realm_Editor {app} />
 			</section>
 		{/if}
 	</div>
-	{#if $projects.length}
+	{#if app.project_datas.length}
 		<div class="width_sm">
-			{#if $levels}
+			{#if app.levels}
 				<section class="card" transition:slide>
-					<Level_Map_Items {app} levels={$levels} />
+					<Level_Map_Items {app} levels={app.levels} />
 				</section>
 			{/if}
-			{#if $selected_realm_id && (($editing_level && $levels) ?? $levels?.length === 0)}
+			{#if app.selected_realm_id && ((app.editing_level && app.levels) ?? app.levels?.length === 0)}
 				<section class="card" transition:slide>
 					<div class="panel p_md">
 						<Level_Form

--- a/src/lib/earbetter/Level_Map.svelte
+++ b/src/lib/earbetter/Level_Map.svelte
@@ -8,12 +8,12 @@
 	import Volume_Control from '$lib/Volume_Control.svelte';
 	import {with_velocity} from '$lib/audio_helpers.js';
 	import Instrument_Control from '$lib/Instrument_Control.svelte';
-	import type {App} from '$lib/earbetter/app.js';
+	import type {App} from '$lib/earbetter/app.svelte.js';
 	import Controls_Instructions from '$lib/earbetter/Controls_Instructions.svelte';
 	import Midi_Input from '$lib/Midi_Input.svelte';
 	import {start_playing, stop_playing} from '$lib/play_note.js';
 	import Realms from '$lib/earbetter/Realms.svelte';
-	import {Level_Data, MISTAKE_HISTORY_LENGTH} from '$lib/earbetter/level.js';
+	import {Level_Data, MISTAKE_HISTORY_LENGTH} from '$lib/earbetter/level.svelte.js';
 	import Realm_Editor from '$lib/earbetter/Realm_Editor.svelte';
 	import Level_Map_Items from '$lib/earbetter/Level_Map_Items.svelte';
 	import Project_Editor from '$lib/earbetter/Project_Editor.svelte';

--- a/src/lib/earbetter/Level_Map_Item.svelte
+++ b/src/lib/earbetter/Level_Map_Item.svelte
@@ -12,21 +12,12 @@
 
 	const {app, level_data}: Props = $props();
 
-	const {
-		editing_level,
-		draft_level_data,
-		selected_project_data,
-		play_level,
-		edit_level,
-		remove_level,
-	} = $derived(app);
-
 	// TODO hacky - the `editing_this_level` is needed when clicking into a level and going back,
 	// the `draft_level_data` is set but `editing_level` may be false,
 	// and we need to show it selected but not the edit button (needs restructuring for a proper fix)
-	const editing_this_level = $derived($draft_level_data === level_data);
-	const editing = $derived($editing_level && editing_this_level);
-	const level_stats = $derived($selected_project_data?.level_stats);
+	const editing_this_level = $derived(app.draft_level_data === level_data);
+	const editing = $derived(app.editing_level && editing_this_level);
+	const level_stats = $derived(app.selected_project_data?.level_stats);
 
 	let removing = $state(false);
 
@@ -41,7 +32,7 @@
 		type="button"
 		class="level_button deselectable"
 		title="play this level"
-		onclick={() => play_level(level_data.id)}
+		onclick={() => app.play_level(level_data.id)}
 		class:selected
 	>
 		{level_data.name}
@@ -52,7 +43,7 @@
 		class:selected={!removing && editing}
 		title={removing ? 'remove level' : editing ? 'stop editing level' : 'edit level'}
 		onclick={() =>
-			removing ? remove_level(level_data.id) : edit_level(editing ? null : level_data)}
+			removing ? app.remove_level(level_data.id) : app.edit_level(editing ? null : level_data)}
 	>
 		{#if removing}✖{:else}✎{/if}
 	</button>

--- a/src/lib/earbetter/Level_Map_Item.svelte
+++ b/src/lib/earbetter/Level_Map_Item.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import {slide} from 'svelte/transition';
 
-	import type {Level_Data} from '$lib/earbetter/level.js';
-	import type {App} from '$lib/earbetter/app.js';
+	import type {Level_Data} from '$lib/earbetter/level.svelte.js';
+	import type {App} from '$lib/earbetter/app.svelte.js';
 	import Level_Stats_Summary from '$lib/earbetter/Level_Stats_Summary.svelte';
 
 	interface Props {

--- a/src/lib/earbetter/Level_Map_Items.svelte
+++ b/src/lib/earbetter/Level_Map_Items.svelte
@@ -10,9 +10,9 @@
 
 	const {app, levels}: Props = $props();
 
-	const {selected_realm_data, editing_level, draft_level_data, edit_level} = $derived(app);
-
-	const editing_draft = $derived($editing_level && !levels.some((d) => d === $draft_level_data));
+	const editing_draft = $derived(
+		app.editing_level && !levels.some((d) => d === app.draft_level_data),
+	);
 
 	const no_levels = $derived(!levels.length);
 
@@ -24,7 +24,7 @@
 			// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
 			(document.querySelector('.level_def_form input') as HTMLInputElement | null)?.focus(); // TODO hacky using the selector
 		} else {
-			edit_level(editing_draft ? null : Level_Data.parse({}));
+			app.edit_level(editing_draft ? null : Level_Data.parse({}));
 		}
 	};
 </script>
@@ -32,7 +32,7 @@
 <div class="panel p_md">
 	<header>
 		<h2 class="my_0">levels</h2>
-		<h3 class="my_0">{$selected_realm_data?.name}</h3>
+		<h3 class="my_0">{app.selected_realm_data?.name}</h3>
 	</header>
 	<menu class="levels unstyled">
 		{#each levels as d (d.id)}

--- a/src/lib/earbetter/Level_Map_Items.svelte
+++ b/src/lib/earbetter/Level_Map_Items.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Level_Map_Item from '$lib/earbetter/Level_Map_Item.svelte';
-	import type {App} from '$lib/earbetter/app.js';
-	import {Level_Data} from '$lib/earbetter/level.js';
+	import type {App} from '$lib/earbetter/app.svelte.js';
+	import {Level_Data} from '$lib/earbetter/level.svelte.js';
 
 	interface Props {
 		app: App;

--- a/src/lib/earbetter/Level_Progress_Indicator.svelte
+++ b/src/lib/earbetter/Level_Progress_Indicator.svelte
@@ -7,8 +7,6 @@
 
 	const {level}: Props = $props();
 
-	const {level_data, trial, status, trials} = $derived(level);
-
 	const to_bg_color = (s: Status, t: Trial | null, ts: Trial[], index: number): string => {
 		return s === 'complete'
 			? 'var(--lighten_5)'
@@ -20,15 +18,19 @@
 	};
 
 	const percent_complete = $derived(
-		$status === 'complete' ? 1 : $trial ? ($trial.index + 0.5) / level_data.trial_count : 0,
+		level.status === 'complete'
+			? 1
+			: level.trial
+				? (level.trial.index + 0.5) / level.level_data.trial_count
+				: 0,
 	);
 </script>
 
 <div class="level_progress_indicator" style:--progress_bar_percent={percent_complete}>
-	{#each {length: level_data.trial_count} as _, index}
+	{#each {length: level.level_data.trial_count} as _, index}
 		<div
 			class="level"
-			style:background-color={to_bg_color($status, $trial, $trials, index)}
+			style:background-color={to_bg_color(level.status, level.trial, level.trials, index)}
 			aria-hidden="true"
 		></div>
 	{/each}

--- a/src/lib/earbetter/Level_Progress_Indicator.svelte
+++ b/src/lib/earbetter/Level_Progress_Indicator.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type {Level, Status, Trial} from '$lib/earbetter/level.js';
+	import type {Level, Status, Trial} from '$lib/earbetter/level.svelte.js';
 
 	interface Props {
 		level: Level;

--- a/src/lib/earbetter/Level_Scene.svelte
+++ b/src/lib/earbetter/Level_Scene.svelte
@@ -4,7 +4,7 @@
 	import {plural} from '@ryanatkn/belt/string.js';
 	import {onMount, untrack} from 'svelte';
 
-	import {Level_Stats, type Level} from '$lib/earbetter/level.js';
+	import {Level_Stats, type Level} from '$lib/earbetter/level.svelte.js';
 	import Piano from '$lib/Piano.svelte';
 	import Level_Progress_Indicator from '$lib/earbetter/Level_Progress_Indicator.svelte';
 	import Trial_Progress_Indicator from '$lib/earbetter/Trial_Progress_Indicator.svelte';
@@ -15,7 +15,7 @@
 	import {with_velocity} from '$lib/audio_helpers.js';
 	import Level_Stats_Summary from '$lib/earbetter/Level_Stats_Summary.svelte';
 	import Text_Burst from '$lib/Text_Burst.svelte';
-	import {get_app} from '$lib/earbetter/app.js';
+	import {get_app} from '$lib/earbetter/app.svelte.js';
 
 	interface Props {
 		level: Level;

--- a/src/lib/earbetter/Level_Scene.svelte
+++ b/src/lib/earbetter/Level_Scene.svelte
@@ -2,7 +2,7 @@
 	import {is_editable, swallow} from '@ryanatkn/belt/dom.js';
 	import {scale, fly} from 'svelte/transition';
 	import {plural} from '@ryanatkn/belt/string.js';
-	import {untrack} from 'svelte';
+	import {onMount, untrack} from 'svelte';
 
 	import {Level_Stats, type Level} from '$lib/earbetter/level.js';
 	import Piano from '$lib/Piano.svelte';
@@ -26,19 +26,19 @@
 	const {level, level_stats, exit_level}: Props = $props();
 
 	const app = get_app();
-	const {playing_notes, midi_access, volume, instrument} = app;
 
 	const ac = get_audio_context();
 
 	let clientWidth: number | undefined = $state();
 
-	const {level_data, mistakes, status, trial, last_guess} = $derived(level);
-	const guessing_index = $derived($trial?.guessing_index);
+	// TODO `level_data` is not reactive, so we can destructure, but should we?
+	const {level_data} = $derived(level);
+	const guessing_index = $derived(level.trial?.guessing_index);
 
-	const pressed_keys = $derived($status === 'presenting_prompt' ? null : $playing_notes);
-	const highlighted_keys = $derived($trial && new Set([$trial.sequence[0]]));
+	const pressed_keys = $derived(level.status === 'presenting_prompt' ? null : app.playing_notes);
+	const highlighted_keys = $derived(level.trial && new Set([level.trial.sequence[0]]));
 
-	$effect(() => {
+	onMount(() => {
 		level.start(); // TODO problem here is the audio context needs to be resumed, so if it's not ready maybe have a start button
 	});
 
@@ -51,10 +51,10 @@
 
 	let last_feedback_status: null | 'success' | 'failure' = $state(null);
 
-	const waiting = $derived($status === 'waiting_for_input');
-	const success = $derived($status === 'showing_success_feedback');
-	const failure = $derived($status === 'showing_failure_feedback');
-	const complete = $derived($status === 'complete');
+	const waiting = $derived(level.status === 'waiting_for_input');
+	const success = $derived(level.status === 'showing_success_feedback');
+	const failure = $derived(level.status === 'showing_failure_feedback');
+	const complete = $derived(level.status === 'complete');
 
 	// TODO better way to do these? callback to `level`?
 	$effect(() => {
@@ -79,7 +79,7 @@
 	let text_burst_offset_y = $state(0);
 	const update_text_burst_position = () => {
 		if (!piano_wrapper_el) return;
-		const guessed = $last_guess;
+		const guessed = level.last_guess;
 		if (guessed === null) return;
 		const note_el = piano_wrapper_el.querySelector(`[data-note="${guessed}"]`);
 		if (!note_el) return;
@@ -110,7 +110,7 @@
 				return;
 			}
 			case ' ': {
-				switch ($status) {
+				switch (level.status) {
 					case 'complete': {
 						swallow(e);
 						exit_level();
@@ -144,13 +144,13 @@
 
 <svelte:window onkeydowncapture={keydown} />
 <Midi_Input
-	{midi_access}
+	midi_access={app.midi_access}
 	onnotestart={(note, velocity) => {
 		// TODO should this be ignored if it's not an enabled key? should the level itself ignore the guess?
-		if ($status === 'complete') {
-			start_playing(app, ac(), note, with_velocity($volume, velocity), $instrument);
+		if (level.status === 'complete') {
+			start_playing(app, ac(), note, with_velocity(app.volume, velocity), app.instrument);
 		} else {
-			console.log(`guessing $status`, $status);
+			console.log(`guessing level.status`, level.status);
 			// TODO should we intercept here if disabled, and just play the blip with no penalty? or should that be a param to `guess`?
 			level.guess(note);
 		}
@@ -173,15 +173,16 @@
 				width={clientWidth - piano_padding * 2}
 				min_note={level_data.min_note}
 				max_note={level_data.max_note}
-				enabled_notes={$trial?.valid_notes}
+				enabled_notes={level.trial?.valid_notes}
 				{pressed_keys}
 				{highlighted_keys}
-				onpress={$status === 'waiting_for_input'
+				onpress={level.status === 'waiting_for_input'
 					? (note) => on_press_key(note)
-					: $status === 'complete'
-						? (note) => start_playing(app, ac(), note, with_velocity($volume, null), $instrument)
+					: level.status === 'complete'
+						? (note) =>
+								start_playing(app, ac(), note, with_velocity(app.volume, null), app.instrument)
 						: undefined}
-				onrelease={$status === 'complete' ? (note) => stop_playing(note) : undefined}
+				onrelease={level.status === 'complete' ? (note) => stop_playing(note) : undefined}
 			/>
 		{/if}
 	</div>
@@ -196,14 +197,14 @@
 					<!-- TODO buggy in Svelte 5 -   -->
 					<div class="panel p_md mb_md box w_100">
 						<div class="panel p_md mb_md box">
-							{#if $mistakes === 0}
+							{#if level.mistakes === 0}
 								<div class="size_xl3 text_align_center">flawless run!</div>
 							{:else}
 								<div class="size_xl3">
-									{$mistakes}
+									{level.mistakes}
 								</div>
 								<div>
-									mistake{plural($mistakes)} this run
+									mistake{plural(level.mistakes)} this run
 								</div>
 							{/if}
 						</div>

--- a/src/lib/earbetter/Level_Scene.svelte
+++ b/src/lib/earbetter/Level_Scene.svelte
@@ -38,6 +38,7 @@
 	const pressed_keys = $derived(level.status === 'presenting_prompt' ? null : app.playing_notes);
 	const highlighted_keys = $derived(level.trial && new Set([level.trial.sequence[0]]));
 
+	// TODO `onMount` makes this not reactive to `level` changing, need to rethink starting it anyway for the audio context init
 	onMount(() => {
 		level.start(); // TODO problem here is the audio context needs to be resumed, so if it's not ready maybe have a start button
 	});

--- a/src/lib/earbetter/Level_Stats_Summary.svelte
+++ b/src/lib/earbetter/Level_Stats_Summary.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
 	import {plural} from '@ryanatkn/belt/string.js';
 
-	import {MISTAKE_HISTORY_LENGTH, type Level_Data, type Level_Stats} from '$lib/earbetter/level.js';
+	import {
+		MISTAKE_HISTORY_LENGTH,
+		type Level_Data,
+		type Level_Stats,
+	} from '$lib/earbetter/level.svelte.js';
 
 	interface Props {
 		level_data: Level_Data;

--- a/src/lib/earbetter/Project_Editor.svelte
+++ b/src/lib/earbetter/Project_Editor.svelte
@@ -9,19 +9,11 @@
 
 	const {app}: Props = $props();
 
-	const {
-		project_datas: projects,
-		editing_project,
-		editing_project_data, // TODO review this and with `project_data` below
-		remove_project,
-		duplicate_project,
-		update_project,
-		create_project,
-	} = $derived(app);
+	const {remove_project, duplicate_project, update_project, create_project} = $derived(app);
 
-	const project_data = $derived($editing_project_data ?? Project_Data.parse({}));
+	const project_data = $derived(app.editing_project_data ?? Project_Data.parse({}));
 
-	const editing = $derived($projects.some((d) => d.id === project_data.id));
+	const editing = $derived(app.project_datas.some((d) => d.id === project_data.id));
 </script>
 
 <div class="panel p_md">
@@ -31,6 +23,6 @@
 		onsubmit={editing ? update_project : create_project}
 		onremove={remove_project}
 		onduplicate={duplicate_project}
-		onclose={() => (editing_project.value = false)}
+		onclose={() => (app.editing_project = false)}
 	/>
 </div>

--- a/src/lib/earbetter/Project_Editor.svelte
+++ b/src/lib/earbetter/Project_Editor.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Project_Form from '$lib/earbetter/Project_Form.svelte';
-	import type {App} from '$lib/earbetter/app.js';
+	import type {App} from '$lib/earbetter/app.svelte.js';
 	import {Project_Data} from '$lib/earbetter/project.js';
 
 	interface Props {

--- a/src/lib/earbetter/Project_Form.svelte
+++ b/src/lib/earbetter/Project_Form.svelte
@@ -36,7 +36,7 @@
 			level_stats: project_data.level_stats,
 		});
 
-	// TODO review this effect to try to remove it
+	// TODO @multiple review this effect to try to remove it
 	$effect(() => {
 		console.log(`set_project_data`, project_data);
 		updated_name = project_data.name;
@@ -50,7 +50,7 @@
 	let updated = $state('');
 	const changed_serialized = $derived(serialized !== updated);
 	let parse_error_message = $state('');
-	// TODO review this effect to try to remove it
+	// TODO @multiple review this effect to try to remove it
 	$effect(() => {
 		project_data;
 		parse_error_message = '';

--- a/src/lib/earbetter/Projects.svelte
+++ b/src/lib/earbetter/Projects.svelte
@@ -9,22 +9,13 @@
 
 	const {app}: Props = $props();
 
-	const {
-		app_data,
-		project_datas,
-		selected_project_id,
-		editing_project,
-		editing_project_id,
-		editing_project_data,
-		load_project,
-		select_project,
-		edit_project,
-		remove_project,
-	} = $derived(app);
+	const {load_project, select_project, edit_project, remove_project} = $derived(app);
 
-	const creating = $derived($editing_project && $selected_project_id !== $editing_project_id);
+	const creating = $derived(
+		app.editing_project && app.selected_project_id !== app.editing_project_id,
+	);
 
-	const {projects} = $derived($app_data);
+	const {projects} = $derived(app.app_data);
 </script>
 
 <div class="panel p_md">
@@ -32,13 +23,14 @@
 		<h2 class="my_0">projects</h2>
 	</header>
 	<Project_Items
-		selected_project_id={$selected_project_id}
-		editing_project_id={$editing_project ? $editing_project_id : null}
+		selected_project_id={app.selected_project_id}
+		editing_project_id={app.editing_project ? app.editing_project_id : null}
 		{projects}
-		project_datas={$project_datas}
+		project_datas={app.project_datas}
 		{load_project}
 		{select_project}
-		edit_project={(p) => edit_project(p === $editing_project_data && $editing_project ? null : p)}
+		edit_project={(p) =>
+			edit_project(p === app.editing_project_data && app.editing_project ? null : p)}
 		{remove_project}
 	/>
 	<button
@@ -47,7 +39,7 @@
 		class:selected={creating}
 		onclick={() => {
 			if (creating) {
-				editing_project.value = false;
+				app.editing_project = false;
 			} else {
 				edit_project(Project_Data.parse({}));
 			}

--- a/src/lib/earbetter/Projects.svelte
+++ b/src/lib/earbetter/Projects.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import {Project_Data} from '$lib/earbetter/project.js';
 	import Project_Items from '$lib/earbetter/Project_Items.svelte';
-	import type {App} from '$lib/earbetter/app.js';
+	import type {App} from '$lib/earbetter/app.svelte.js';
 
 	interface Props {
 		app: App; // TODO maybe change to be more granular objects?

--- a/src/lib/earbetter/Realm_Editor.svelte
+++ b/src/lib/earbetter/Realm_Editor.svelte
@@ -9,23 +9,14 @@
 
 	const {app}: Props = $props();
 
-	const {
-		realms,
-		selected_realm_data,
-		editing_realm,
-		editing_realm_data,
-		remove_realm,
-		duplicate_realm,
-		update_realm,
-		create_realm,
-	} = $derived(app);
+	const {remove_realm, duplicate_realm, update_realm, create_realm} = $derived(app);
 
-	const realm_data = $derived($editing_realm_data ?? Realm_Data.parse({}));
+	const realm_data = $derived(app.editing_realm_data ?? Realm_Data.parse({}));
 
-	const editing = $derived($realms ? $realms.some((d) => d.id === realm_data.id) : false);
+	const editing = $derived(app.realms ? app.realms.some((d) => d.id === realm_data.id) : false);
 
-	$inspect(`$selected_realm_data`, $selected_realm_data);
-	$inspect(`$realms`, $realms);
+	$inspect(`app.selected_realm_data`, app.selected_realm_data);
+	$inspect(`app.realms`, app.realms);
 </script>
 
 <div class="panel p_md">
@@ -35,6 +26,6 @@
 		onsubmit={editing ? update_realm : create_realm}
 		onremove={(realm_id) => remove_realm(realm_id)}
 		onduplicate={(realm_id) => duplicate_realm(realm_id)}
-		onclose={() => (editing_realm.value = false)}
+		onclose={() => (app.editing_realm = false)}
 	/>
 </div>

--- a/src/lib/earbetter/Realm_Editor.svelte
+++ b/src/lib/earbetter/Realm_Editor.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Realm_Form from '$lib/earbetter/Realm_Form.svelte';
-	import type {App} from '$lib/earbetter/app.js';
+	import type {App} from '$lib/earbetter/app.svelte.js';
 	import {Realm_Data} from '$lib/earbetter/realm.js';
 
 	interface Props {

--- a/src/lib/earbetter/Realm_Form.svelte
+++ b/src/lib/earbetter/Realm_Form.svelte
@@ -31,7 +31,7 @@
 			levels: realm_data.levels,
 		});
 
-	// TODO review this effect to try to remove it
+	// TODO @multiple review this effect to try to remove it
 	$effect(() => {
 		console.log(`set_realm_data`, realm_data);
 		updated_name = realm_data.name;
@@ -45,7 +45,7 @@
 	let updated = $state('');
 	const changed_serialized = $derived(serialized !== updated);
 	let parse_error_message = $state('');
-	// TODO review this effect to try to remove it
+	// TODO @multiple review this effect to try to remove it
 	$effect(() => {
 		realm_data;
 		parse_error_message = '';

--- a/src/lib/earbetter/Realm_Stats_Summary.svelte
+++ b/src/lib/earbetter/Realm_Stats_Summary.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type {Realm_Data} from '$lib/earbetter/realm.js';
-	import {MISTAKE_HISTORY_LENGTH, type Level_Stats} from '$lib/earbetter/level.js';
+	import {MISTAKE_HISTORY_LENGTH, type Level_Stats} from '$lib/earbetter/level.svelte.js';
 
 	interface Props {
 		realm_data: Realm_Data;

--- a/src/lib/earbetter/Realms.svelte
+++ b/src/lib/earbetter/Realms.svelte
@@ -3,7 +3,7 @@
 
 	import {Realm_Data} from '$lib/earbetter/realm.js';
 	import Realm_Items from '$lib/earbetter/Realm_Items.svelte';
-	import type {App} from '$lib/earbetter/app.js';
+	import type {App} from '$lib/earbetter/app.svelte.js';
 
 	interface Props {
 		app: App; // TODO maybe change to be more granular objects?

--- a/src/lib/earbetter/Realms.svelte
+++ b/src/lib/earbetter/Realms.svelte
@@ -11,23 +11,15 @@
 
 	const {app}: Props = $props();
 
-	const {
-		selected_project_data,
-		realms,
-		selected_realm_data,
-		editing_realm,
-		editing_realm_id,
-		editing_realm_data,
-		select_realm,
-		edit_realm,
-		remove_realm,
-	} = $derived(app);
+	const {select_realm, edit_realm, remove_realm} = $derived(app);
 
 	const creating = $derived(
-		$editing_realm && !!$editing_realm_data && $selected_realm_data?.id !== $editing_realm_data.id,
+		app.editing_realm &&
+			!!app.editing_realm_data &&
+			app.selected_realm_data?.id !== app.editing_realm_data.id,
 	);
 
-	const no_realms = $derived(!$realms?.length);
+	const no_realms = $derived(!app.realms?.length);
 
 	const click_create_new = () => {
 		if (no_realms) {
@@ -35,7 +27,7 @@
 			// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
 			(document.querySelector('.realm_def_form input') as HTMLInputElement | null)?.focus(); // TODO hacky using the selector
 		} else if (creating) {
-			editing_realm.value = false;
+			app.editing_realm = false;
 		} else {
 			edit_realm(Realm_Data.parse({}));
 		}
@@ -46,15 +38,15 @@
 	<header>
 		<h2 class="my_0">realms</h2>
 	</header>
-	{#if $realms && $selected_project_data}
+	{#if app.realms && app.selected_project_data}
 		<div class="pb_md" transition:slide>
 			<Realm_Items
-				project_data={$selected_project_data}
-				selected_realm_data={$selected_realm_data}
-				realms={$realms}
-				editing_realm_id={$editing_realm ? $editing_realm_id : null}
+				project_data={app.selected_project_data}
+				selected_realm_data={app.selected_realm_data}
+				realms={app.realms}
+				editing_realm_id={app.editing_realm ? app.editing_realm_id : null}
 				{select_realm}
-				edit_realm={(p) => edit_realm(p === $editing_realm_data && $editing_realm ? null : p)}
+				edit_realm={(p) => edit_realm(p === app.editing_realm_data && app.editing_realm ? null : p)}
 				{remove_realm}
 			/>
 		</div>

--- a/src/lib/earbetter/Trial_Progress_Indicator.svelte
+++ b/src/lib/earbetter/Trial_Progress_Indicator.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import {fade} from 'svelte/transition';
 
-	import type {Level, Status} from '$lib/earbetter/level.js';
+	import type {Level, Status} from '$lib/earbetter/level.svelte.js';
 
 	interface Props {
 		level: Level;

--- a/src/lib/earbetter/Trial_Progress_Indicator.svelte
+++ b/src/lib/earbetter/Trial_Progress_Indicator.svelte
@@ -9,9 +9,9 @@
 
 	const {level}: Props = $props();
 
-	const {trial, status} = $derived(level);
-
-	const current_index = $derived($trial ? $trial.presenting_index ?? $trial.guessing_index : null);
+	const current_index = $derived(
+		level.trial ? level.trial.presenting_index ?? level.trial.guessing_index : null,
+	);
 
 	const to_bg_color = (s: Status, index: number, current_index: number | null): string =>
 		s === 'showing_failure_feedback'
@@ -25,28 +25,28 @@
 						: 'transparent';
 
 	const percent_complete = $derived(
-		$status === 'initial' || $status === 'showing_failure_feedback'
+		level.status === 'initial' || level.status === 'showing_failure_feedback'
 			? 0
-			: $status === 'complete' || $status === 'showing_success_feedback'
+			: level.status === 'complete' || level.status === 'showing_success_feedback'
 				? 1
-				: $trial?.presenting_index != null
-					? ($trial.presenting_index + 0.5) / $trial.sequence.length
-					: $trial?.guessing_index != null
-						? ($trial.guessing_index + 0.5) / $trial.sequence.length
+				: level.trial?.presenting_index != null
+					? (level.trial.presenting_index + 0.5) / level.trial.sequence.length
+					: level.trial?.guessing_index != null
+						? (level.trial.guessing_index + 0.5) / level.trial.sequence.length
 						: 0,
 	);
 </script>
 
-{#if $trial}
+{#if level.trial}
 	<div
 		class="trial_progress_indicator"
 		style:--progress_bar_percent={percent_complete}
 		transition:fade
 	>
-		{#each {length: $trial.sequence.length} as _, index}
+		{#each {length: level.trial.sequence.length} as _, index}
 			<div
 				class="trial"
-				style:background-color={to_bg_color($status, index, current_index)}
+				style:background-color={to_bg_color(level.status, index, current_index)}
 				aria-hidden="true"
 			></div>
 		{/each}

--- a/src/lib/earbetter/app.svelte.ts
+++ b/src/lib/earbetter/app.svelte.ts
@@ -9,7 +9,7 @@ import {
 	Level,
 	Level_Data,
 	type Level_Id,
-} from '$lib/earbetter/level.js';
+} from '$lib/earbetter/level.svelte.js';
 import {Project_Data, Project_Id, Project_Name} from '$lib/earbetter/project.js';
 import {load_from_storage, set_in_storage} from '$lib/storage.js';
 import {Realm_Id, Realm_Data} from '$lib/earbetter/realm.js';

--- a/src/lib/earbetter/app.svelte.ts
+++ b/src/lib/earbetter/app.svelte.ts
@@ -52,7 +52,7 @@ export class App {
 	// TODO wheres the source of truth?
 	// currently manually syncing the same changes to both `app_data` `projects` --
 	// mixing serialization concerns with runtime representations
-	app_data: App_Data = $state.frozen(this.load());
+	app_data: App_Data = $state.frozen()!;
 
 	// TODO does initializing these to the defaults without the app data cause any weirdness? creating them eagerly because we can't do `this.volume = $state(...)` in the constructor
 	volume: Volume = $state(DEFAULT_VOLUME);
@@ -133,6 +133,7 @@ export class App {
 		initial_site_data: Site_Data | null = null,
 		public readonly storage_key = 'app',
 	) {
+		this.app_data = this.load();
 		console.log(`app_data`, this.app_data);
 
 		if (initial_site_data) {

--- a/src/lib/earbetter/app.ts
+++ b/src/lib/earbetter/app.ts
@@ -1,6 +1,6 @@
 import {goto} from '$app/navigation';
 import {z} from 'zod';
-import {getContext, setContext} from 'svelte';
+import {getContext, setContext, untrack} from 'svelte';
 import {base} from '$app/paths';
 
 import {
@@ -72,8 +72,8 @@ export class App {
 	show_trainer_help: boolean = $derived(this.app_data.show_trainer_help);
 	toggle_trainer_help = (): void => {
 		this.app_data = {
-			...this.app_data.peek(),
-			show_trainer_help: !this.show_trainer_help.peek(),
+			...this.app_data,
+			show_trainer_help: !this.show_trainer_help,
 		};
 	};
 
@@ -155,7 +155,7 @@ export class App {
 		// save changes to `selected_project_id` and `selected_realm_id` back to the `app_data`,
 		// these could be decoupled but are often fired together
 		$effect(() => {
-			const app_data = this.app_data.peek();
+			const app_data = untrack(() => this.app_data);
 			const selected_project_id = this.selected_project_id;
 			const selected_realm_id = this.selected_realm_id;
 			if (

--- a/src/lib/earbetter/app.ts
+++ b/src/lib/earbetter/app.ts
@@ -1,6 +1,5 @@
 import {goto} from '$app/navigation';
 import {z} from 'zod';
-import {signal, type Signal, computed, effect, type ReadonlySignal} from '@preact/signals-core';
 import {getContext, setContext} from 'svelte';
 import {base} from '$app/paths';
 

--- a/src/lib/earbetter/app.ts
+++ b/src/lib/earbetter/app.ts
@@ -52,12 +52,12 @@ export class App {
 	// TODO wheres the source of truth?
 	// currently manually syncing the same changes to both `app_data` `projects` --
 	// mixing serialization concerns with runtime representations
-	app_data: App_Data = $state(this.load());
+	app_data: App_Data = $state.frozen(this.load());
 
 	// TODO does initializing these to the defaults without the app data cause any weirdness? creating them eagerly because we can't do `this.volume = $state(...)` in the constructor
 	volume: Volume = $state(DEFAULT_VOLUME);
 	instrument: Instrument = $state(DEFAULT_INSTRUMENT);
-	scale: Scale = $state(DEFAULT_SCALE);
+	scale: Scale = $state.frozen(DEFAULT_SCALE);
 	key: Pitch_Class = $state(pitch_classes[0]);
 	enabled_notes: Set<Midi> | null = $derived(
 		this.scale.name === 'chromatic' ? null : to_notes_in_scale(this.scale, this.key),

--- a/src/lib/earbetter/app.ts
+++ b/src/lib/earbetter/app.ts
@@ -200,14 +200,14 @@ export class App {
 		const {projects} = app_data;
 		if (project_data) {
 			if (!projects.some((p) => p.id === id)) {
-				this.app_data.value = {
+				this.app_data = {
 					...app_data,
 					projects: projects.concat({id, name: project_data.name}),
 				};
 			}
 		} else {
 			if (projects.some((p) => p.id === id)) {
-				this.app_data.value = {...app_data, projects: projects.filter((p) => p.id !== id)};
+				this.app_data = {...app_data, projects: projects.filter((p) => p.id !== id)};
 			}
 		}
 	};
@@ -218,7 +218,7 @@ export class App {
 		console.log(`loaded`, loaded);
 		if (loaded) {
 			// TODO batch if this code stays imperative like this
-			this.project_datas.value = this.project_datas.peek().concat(loaded);
+			this.project_datas = this.project_datas.peek().concat(loaded);
 			return loaded;
 		} else {
 			console.log(`load_project failed, creating new`, id);
@@ -231,34 +231,34 @@ export class App {
 	select_project = (id: Project_Id | null): void => {
 		console.log('select_project', id);
 		if (!id) {
-			this.selected_project_id.value = null;
+			this.selected_project_id = null;
 			return;
 		}
 		const project_data =
 			this.project_datas.peek().find((d) => d.id === id) ?? this.load_project(id);
 		if (!project_data) console.error('failed to find or load def', id);
-		this.selected_project_id.value = project_data?.id ?? null;
-		this.selected_realm_id.value = project_data?.realms[0]?.id ?? null;
+		this.selected_project_id = project_data?.id ?? null;
+		this.selected_realm_id = project_data?.realms[0]?.id ?? null;
 	};
 
 	edit_project = (project_data: Project_Data | null): void => {
 		console.log('edit_project', project_data);
 		if (!project_data) {
-			this.editing_project.value = false;
-			this.draft_project_data.value = null;
+			this.editing_project = false;
+			this.draft_project_data = null;
 			return;
 		}
-		this.editing_project.value = true;
+		this.editing_project = true;
 		const {id} = project_data;
 		const found = this.project_datas.peek().find((d) => d.id === id);
 		if (found) {
 			// existing project
-			this.selected_project_id.value = id;
-			this.editing_project_draft.value = false;
+			this.selected_project_id = id;
+			this.editing_project_draft = false;
 		} else {
 			// draft project
-			this.draft_project_data.value = project_data;
-			this.editing_project_draft.value = true;
+			this.draft_project_data = project_data;
+			this.editing_project_draft = true;
 		}
 	};
 
@@ -268,13 +268,13 @@ export class App {
 		const existing = projects.find((d) => d.id === id);
 		if (!existing) return;
 		// TODO syncing `app_data` with `projects` is awkward
-		this.app_data.value = {
+		this.app_data = {
 			...this.app_data.peek(),
 			projects: projects.filter((p) => p.id !== id),
 		};
-		this.project_datas.value = this.project_datas.peek().filter((p) => p.id !== id);
+		this.project_datas = this.project_datas.peek().filter((p) => p.id !== id);
 		if (this.selected_project_id.peek() === id) {
-			this.selected_project_id.value =
+			this.selected_project_id =
 				this.project_datas.peek()[0]?.id ?? // eslint-disable-line @typescript-eslint/no-unnecessary-condition
 				this.load_project(this.app_data.peek().projects[0]?.id)?.id ??
 				null;
@@ -292,15 +292,15 @@ export class App {
 			return existing;
 		}
 		// TODO syncing `app_data` with `projects` is awkward
-		this.app_data.value = {
+		this.app_data = {
 			...this.app_data.peek(),
 			projects: this.app_data.peek().projects.concat({id, name: project_data.name}),
 		};
-		this.project_datas.value = projects.concat(project_data);
-		this.selected_project_id.value = id;
-		this.editing_project.value = false;
+		this.project_datas = projects.concat(project_data);
+		this.selected_project_id = id;
+		this.editing_project = false;
 		if (this.draft_project_data.peek() === project_data) {
-			this.draft_project_data.value = null;
+			this.draft_project_data = null;
 		}
 		this.save_project(id);
 		return project_data;
@@ -320,10 +320,10 @@ export class App {
 			name: to_next_name(name, projects),
 		});
 		this.create_project(new_project_data);
-		this.draft_project_data.value = new_project_data; // TODO move to component?
-		this.selected_project_id.value = new_project_data.id;
-		this.editing_project_draft.value = true;
-		this.editing_project.value = true;
+		this.draft_project_data = new_project_data; // TODO move to component?
+		this.selected_project_id = new_project_data.id;
+		this.editing_project_draft = true;
+		this.editing_project = true;
 	};
 
 	update_project = (project_data: Project_Data): void => {
@@ -339,7 +339,7 @@ export class App {
 		// TODO syncing `app_data` with `projects` is awkward
 		if (project_data.name !== existing.name) {
 			const app_data = this.app_data.peek();
-			this.app_data.value = {
+			this.app_data = {
 				...app_data,
 				projects: app_data.projects.map((p) =>
 					p.id === id ? {id: p.id, name: project_data.name} : p,
@@ -348,47 +348,47 @@ export class App {
 		}
 		const updated = projects.slice();
 		updated[index] = project_data;
-		this.project_datas.value = updated;
+		this.project_datas = updated;
 		this.save_project(id);
 	};
 
 	select_realm = (id: Realm_Id | null): void => {
 		console.log('select_realm', id);
 		if (!id) {
-			this.selected_realm_id.value = null;
+			this.selected_realm_id = null;
 			return;
 		}
 		const realm_data = this.realms.peek()?.find((d) => d.id === id);
 		if (!realm_data) return; // TODO hm, report an error? how to handle?
-		this.selected_realm_id.value = id;
-		this.editing_realm_draft.value = false;
+		this.selected_realm_id = id;
+		this.editing_realm_draft = false;
 		// TODO derive instead of manually checking? might not be needed with a restructuring that saves the editing state in the tree
 		if (
 			this.draft_level_data.peek() &&
 			!realm_data.levels.includes(this.draft_level_data.peek()!)
 		) {
-			this.draft_level_data.value = null;
+			this.draft_level_data = null;
 		}
 	};
 
 	edit_realm = (realm_data: Realm_Data | null): void => {
 		console.log('edit_realm', realm_data);
 		if (!realm_data) {
-			this.editing_realm.value = false;
-			this.draft_realm_data.value = null;
+			this.editing_realm = false;
+			this.draft_realm_data = null;
 			return;
 		}
-		this.editing_realm.value = true;
+		this.editing_realm = true;
 		const {id} = realm_data;
 		const found = this.realms.peek()?.find((d) => d.id === id);
 		if (found) {
 			// existing realm
-			this.selected_realm_id.value = id;
-			this.editing_realm_draft.value = false;
+			this.selected_realm_id = id;
+			this.editing_realm_draft = false;
 		} else {
 			// draft realm
-			this.draft_realm_data.value = realm_data;
-			this.editing_realm_draft.value = true;
+			this.draft_realm_data = realm_data;
+			this.editing_realm_draft = true;
 		}
 	};
 
@@ -406,10 +406,10 @@ export class App {
 			return;
 		}
 		if (id === this.editing_realm_id.peek()) {
-			this.editing_realm.value = false; // TODO move to component?
+			this.editing_realm = false; // TODO move to component?
 		}
 		if (id === this.selected_realm_id.peek()) {
-			this.selected_realm_id.value = null;
+			this.selected_realm_id = null;
 		}
 		this.update_project({
 			...project_data,
@@ -433,8 +433,8 @@ export class App {
 		const {id: _, name, ...rest} = realm_data;
 		const new_realm_data = Realm_Data.parse({...rest, name: to_next_name(name, realms)});
 		this.create_realm(new_realm_data);
-		this.draft_realm_data.value = new_realm_data; // TODO move to component?
-		this.selected_realm_id.value = new_realm_data.id;
+		this.draft_realm_data = new_realm_data; // TODO move to component?
+		this.selected_realm_id = new_realm_data.id;
 	};
 
 	create_realm = (realm_data: Realm_Data): void => {
@@ -454,10 +454,10 @@ export class App {
 		}
 
 		this.update_project({...project_data, realms: realms.concat(realm_data)});
-		this.selected_realm_id.value = realm_data.id;
+		this.selected_realm_id = realm_data.id;
 		// TODO is awkward but works, should it be an effect?
 		if (this.draft_realm_data.peek()?.id === realm_data.id) {
-			this.editing_realm.value = false;
+			this.editing_realm = false;
 		}
 	};
 
@@ -478,7 +478,7 @@ export class App {
 		const updated = realms.slice();
 		updated[index] = realm_data;
 		this.update_project({...project_data, realms: updated});
-		this.selected_realm_id.value = id;
+		this.selected_realm_id = id;
 	};
 
 	play_level = async (id: Level_Id): Promise<void> => {
@@ -488,14 +488,14 @@ export class App {
 			console.error('cannot find level_data with id', id);
 			return;
 		}
-		this.draft_level_data.value = level_data; // for better UX, so when the user navigates back it's still being edited
+		this.draft_level_data = level_data; // for better UX, so when the user navigates back it's still being edited
 		await goto(to_level_url(level_data));
 	};
 
 	edit_level = (level_data: Level_Data | null): void => {
 		console.log('edit_level', level_data);
-		this.editing_level.value = !!level_data;
-		this.draft_level_data.value = level_data;
+		this.editing_level = !!level_data;
+		this.draft_level_data = level_data;
 	};
 
 	remove_level = (id: Level_Id): void => {
@@ -511,8 +511,8 @@ export class App {
 			const {levels} = realm_data;
 			const level_data_index = levels.findIndex((d) => d.id === id);
 			if (level_data_index === -1) continue;
-			if (id === this.draft_level_data.value?.id) {
-				this.draft_level_data.value = null;
+			if (id === this.draft_level_data?.id) {
+				this.draft_level_data = null;
 			}
 			const next_realms = realms.slice();
 			const next_levels = levels.slice();
@@ -558,8 +558,8 @@ export class App {
 		};
 
 		this.update_project({...project_data, realms: next_realms});
-		this.editing_level.value = false;
-		this.draft_level_data.value = null;
+		this.editing_level = false;
+		this.draft_level_data = null;
 
 		return;
 	};
@@ -580,8 +580,8 @@ export class App {
 		const {id: _, name, ...rest} = level_data;
 		const new_level_data = Level_Data.parse({...rest, name: to_next_name(name, levels)});
 		this.create_level(new_level_data);
-		this.editing_level.value = true;
-		this.draft_level_data.value = new_level_data; // TODO move to component?
+		this.editing_level = true;
+		this.draft_level_data = new_level_data; // TODO move to component?
 	};
 
 	update_level = (level_data: Level_Data): void => {
@@ -603,7 +603,7 @@ export class App {
 			const next_realms = realms.slice();
 			next_realms[i] = {...realm_data, levels: next_levels};
 			this.update_project({...project_data, realms: next_realms});
-			this.draft_level_data.value = level_data; // TODO maybe push to the component?
+			this.draft_level_data = level_data; // TODO maybe push to the component?
 			return;
 		}
 		console.error('cannot find level_data with id', id);
@@ -627,7 +627,7 @@ export class App {
 		}
 		console.log('setting `active_level_data`', value);
 		this.level.peek()?.dispose(); // TODO better way to do this? doing it in the `this.level` derived is hacky
-		this.active_level_data.value = value;
+		this.active_level_data = value;
 	}
 
 	/**

--- a/src/lib/earbetter/level.svelte.ts
+++ b/src/lib/earbetter/level.svelte.ts
@@ -9,7 +9,7 @@ import type {Milliseconds} from '$lib/audio_helpers.js';
 import {serialize_to_hash} from '$lib/url.js';
 import {to_random_id} from '$lib/id.js';
 import type {Get_Audio_Context} from '$lib/audio_context.js';
-import type {App} from '$lib/earbetter/app.js';
+import type {App} from '$lib/earbetter/app.svelte.js';
 
 // TODO this isn't idiomatic signals code yet, uses `peek` too much
 

--- a/src/lib/earbetter/level.svelte.ts
+++ b/src/lib/earbetter/level.svelte.ts
@@ -115,14 +115,14 @@ export class Level {
 	}
 
 	present_trial_prompt = async (): Promise<void> => {
-		const $trial = this.trial;
-		if (!$trial) return;
-		console.log('present_trial_prompt', $trial.sequence);
-		this.trial = {...$trial, guessing_index: 0};
+		const trial = this.trial;
+		if (!trial) return;
+		console.log('present_trial_prompt', trial.sequence);
+		this.trial = {...trial, guessing_index: 0};
 		const current_seq_id = ++this.seq_id;
-		const sequence_length = $trial.sequence.length;
+		const sequence_length = trial.sequence.length;
 		for (let i = 0; i < sequence_length; i++) {
-			const note = $trial.sequence[i];
+			const note = trial.sequence[i];
 			this.trial = {
 				...this.trial,
 				presenting_index: i,
@@ -143,10 +143,10 @@ export class Level {
 	// TODO helpful to have a return value?
 	guess = (note: Midi): void => {
 		if (this.status !== 'waiting_for_input') return;
-		const $trial = this.trial;
-		const guessing_index = $trial?.guessing_index;
-		if (!$trial || guessing_index == null) return;
-		const actual = get_correct_guess_for_trial($trial);
+		const trial = this.trial;
+		const guessing_index = trial?.guessing_index;
+		if (!trial || guessing_index == null) return;
+		const actual = get_correct_guess_for_trial(trial);
 		console.log('guess', guessing_index, note, actual);
 
 		this.last_guess = note;
@@ -162,7 +162,7 @@ export class Level {
 				DEFAULT_NOTE_DURATION_FAILED,
 				this.app.instrument,
 			);
-			if (guessing_index === 0 || !$trial.valid_notes.has(note)) {
+			if (guessing_index === 0 || !trial.valid_notes.has(note)) {
 				return; // no penalty or delay if this is the first one
 			}
 			// TODO should this be "on enter showing_failure_feedback state" logic?
@@ -173,7 +173,7 @@ export class Level {
 		}
 
 		// guess is correct
-		const sequence_length = $trial.sequence.length;
+		const sequence_length = trial.sequence.length;
 		const duration =
 			sequence_length < DEFAULT_SEQUENCE_LENGTH ? DEFAULT_NOTE_DURATION_2 : DEFAULT_NOTE_DURATION; // TODO refactor, see elsewhere
 		void play_note(this.app, this.ac(), note, this.app.volume, duration, this.app.instrument);
@@ -182,7 +182,7 @@ export class Level {
 			// if more -> update current response index
 			this.update_status('showing_success_feedback');
 			// TODO should this be "on enter showing_success_feedback state" logic?
-			if ($trial.index < this.level_data.trial_count - 1) {
+			if (trial.index < this.level_data.trial_count - 1) {
 				console.log('guess correct and done with trial');
 				setTimeout(() => this.next_trial(), DEFAULT_FEEDBACK_DURATION);
 			} else {
@@ -193,27 +193,27 @@ export class Level {
 			// SUCCESS -> no status change because we show no visible positive feedback to users until the end
 			console.log('guess correct but not done');
 			this.trial = {
-				...$trial,
+				...trial,
 				guessing_index: guessing_index + 1,
 			};
 		}
 	};
 
 	retry_trial = (): void => {
-		const $status = this.status;
+		const status = this.status;
 		if (
-			$status !== 'waiting_for_input' &&
-			$status !== 'showing_success_feedback' &&
-			$status !== 'showing_failure_feedback'
+			status !== 'waiting_for_input' &&
+			status !== 'showing_success_feedback' &&
+			status !== 'showing_failure_feedback'
 		) {
 			return;
 		}
-		const $trial = this.trial;
-		if (!$trial) return;
+		const trial = this.trial;
+		if (!trial) return;
 		// TODO should this be "on enter presenting_prompt state" logic?
 		this.trial = {
-			...$trial,
-			retry_count: $trial.retry_count + 1,
+			...trial,
+			retry_count: trial.retry_count + 1,
 		};
 		this.update_status('presenting_prompt');
 	};
@@ -225,10 +225,10 @@ export class Level {
 		const next_trial = create_next_trial(this.level_data, this.trial);
 		console.log('next trial', next_trial);
 		// TODO should this be "on enter presenting_prompt state" logic?
-		const $trials = this.trials;
-		if ($trials.length === 0) this.mistakes = 0;
+		const trials = this.trials;
+		if (trials.length === 0) this.mistakes = 0;
 		this.trial = next_trial;
-		this.trials = [...$trials, next_trial];
+		this.trials = [...trials, next_trial];
 		this.update_status('presenting_prompt');
 	};
 

--- a/src/lib/earbetter/level.ts
+++ b/src/lib/earbetter/level.ts
@@ -95,7 +95,7 @@ export class Level {
 
 	start = (): void => {
 		console.log('start level');
-		if (this.status.peek() !== 'initial') return;
+		if (this.status !== 'initial') return;
 		this.next_trial();
 	};
 

--- a/src/lib/earbetter/project.ts
+++ b/src/lib/earbetter/project.ts
@@ -2,7 +2,7 @@ import {z} from 'zod';
 import {random_item} from '@ryanatkn/belt/random.js';
 import type {Flavored} from '@ryanatkn/belt/types.js';
 
-import {DEFAULT_LEVEL_STATS, Level_Stats} from '$lib/earbetter/level.js';
+import {DEFAULT_LEVEL_STATS, Level_Stats} from '$lib/earbetter/level.svelte.js';
 import {emojis} from '$lib/emoji.js';
 import {Realm_Data} from '$lib/earbetter/realm.js';
 import {to_random_id} from '$lib/id.js';

--- a/src/lib/earbetter/realm.ts
+++ b/src/lib/earbetter/realm.ts
@@ -1,7 +1,7 @@
 import {z} from 'zod';
 import type {Flavored} from '@ryanatkn/belt/types.js';
 
-import {Level_Data} from '$lib/earbetter/level.js';
+import {Level_Data} from '$lib/earbetter/level.svelte.js';
 import {to_random_id} from '$lib/id.js';
 
 export const Realm_Id = z.string();

--- a/src/lib/earbetter/realm_helpers.ts
+++ b/src/lib/earbetter/realm_helpers.ts
@@ -1,6 +1,6 @@
 import {interval_names, lookup_scale, to_scale_notes, type Scale_Name} from '$lib/music.js';
 import {Realm_Data, Realm_Name} from '$lib/earbetter/realm.js';
-import type {Level_Data} from '$lib/earbetter/level.js';
+import type {Level_Data} from '$lib/earbetter/level.svelte.js';
 
 // TODO expand the default levels
 // variants that go down, not just up

--- a/src/lib/midi_access.ts
+++ b/src/lib/midi_access.ts
@@ -16,7 +16,7 @@ export const reset_midi_access = (state: {midi_access: MIDIAccess | null}): void
 export const request_access = async (state: {
 	midi_access: MIDIAccess | null;
 }): Promise<MIDIAccess | null> => {
-	const existing = state.midi_access.peek();
+	const existing = state.midi_access;
 	if (existing) {
 		return existing;
 	}

--- a/src/lib/midi_access.ts
+++ b/src/lib/midi_access.ts
@@ -1,5 +1,3 @@
-import type {Signal} from '@preact/signals-core';
-
 import type {MIDIAccess} from '$lib/WebMIDI.js';
 import {request_midi_access} from '$lib/midi_helpers.js';
 

--- a/src/lib/midi_access.ts
+++ b/src/lib/midi_access.ts
@@ -6,15 +6,15 @@ import {request_midi_access} from '$lib/midi_helpers.js';
 let requesting: Promise<MIDIAccess | null> | undefined;
 
 // TODO @multiple source from `audio` in context, delete this or heavily refactor
-export const reset_midi_access = (state: {midi_access: Signal<MIDIAccess | null>}): void => {
+export const reset_midi_access = (state: {midi_access: MIDIAccess | null}): void => {
 	console.log('resetting midi_access');
 	requesting = undefined;
-	state.midi_access.value = null;
+	state.midi_access = null;
 };
 
 // TODO @multiple source from `audio` in context, this is convoluted for race conditions, probably doesn't need to be
 export const request_access = async (state: {
-	midi_access: Signal<MIDIAccess | null>;
+	midi_access: MIDIAccess | null;
 }): Promise<MIDIAccess | null> => {
 	const existing = state.midi_access.peek();
 	if (existing) {
@@ -31,7 +31,7 @@ export const request_access = async (state: {
 		if (r !== requesting) {
 			return requesting; // eslint-disable-line @typescript-eslint/return-await
 		}
-		state.midi_access.value = value;
+		state.midi_access = value;
 		return value;
 	} catch (err) {
 		console.error('request_access failed', err);

--- a/src/lib/play_note.ts
+++ b/src/lib/play_note.ts
@@ -1,5 +1,3 @@
-import type {Signal} from '@preact/signals-core';
-
 import {
 	DEFAULT_VOLUME,
 	SMOOTH_GAIN_TIME_CONSTANT,
@@ -16,7 +14,7 @@ import {type Midi, midi_to_freq} from '$lib/music.js';
 // Needs a full rethink with the `Audio` class idea.
 
 export const play_note = (
-	state: {playing_notes: Signal<Set<Midi>>},
+	state: {playing_notes: Set<Midi>},
 	ac: AudioContext,
 	note: Midi,
 	volume: Volume,
@@ -46,7 +44,7 @@ const stop_osc = (
 export type Stop_Playing = () => void;
 
 export const start_playing_note = (
-	state: {playing_notes: Signal<Set<Midi>>},
+	state: {playing_notes: Set<Midi>},
 	ac: AudioContext,
 	note: Midi,
 	volume: Volume = DEFAULT_VOLUME,
@@ -64,9 +62,9 @@ export const start_playing_note = (
 	osc.start();
 	osc.connect(gain);
 
-	const next_playing_notes = new Set(state.playing_notes.peek());
+	const next_playing_notes: Set<Midi> = new Set(state.playing_notes.peek());
 	next_playing_notes.add(note);
-	state.playing_notes.value = next_playing_notes;
+	state.playing_notes = next_playing_notes;
 
 	let disposed = false;
 	return () => {
@@ -76,9 +74,9 @@ export const start_playing_note = (
 		console.log(`stop playing note`, note);
 		stop_osc(ac, 10, gain, osc);
 
-		const next_playing_notes = new Set(state.playing_notes.peek());
+		const next_playing_notes: Set<Midi> = new Set(state.playing_notes.peek());
 		next_playing_notes.delete(note);
-		state.playing_notes.value = next_playing_notes;
+		state.playing_notes = next_playing_notes;
 	};
 };
 
@@ -89,7 +87,7 @@ export const start_playing_note = (
 const playing: Map<Midi, Stop_Playing> = new Map(); // global cache used to enforce that at most one of each note plays
 
 export const start_playing = (
-	state: {playing_notes: Signal<Set<Midi>>},
+	state: {playing_notes: Set<Midi>},
 	ac: AudioContext,
 	note: Midi,
 	volume?: Volume,

--- a/src/lib/play_note.ts
+++ b/src/lib/play_note.ts
@@ -62,7 +62,7 @@ export const start_playing_note = (
 	osc.start();
 	osc.connect(gain);
 
-	const next_playing_notes: Set<Midi> = new Set(state.playing_notes.peek());
+	const next_playing_notes: Set<Midi> = new Set(state.playing_notes);
 	next_playing_notes.add(note);
 	state.playing_notes = next_playing_notes;
 
@@ -74,7 +74,7 @@ export const start_playing_note = (
 		console.log(`stop playing note`, note);
 		stop_osc(ac, 10, gain, osc);
 
-		const next_playing_notes: Set<Midi> = new Set(state.playing_notes.peek());
+		const next_playing_notes: Set<Midi> = new Set(state.playing_notes);
 		next_playing_notes.delete(note);
 		state.playing_notes = next_playing_notes;
 	};

--- a/src/lib/projects/default_project.ts
+++ b/src/lib/projects/default_project.ts
@@ -1,4 +1,4 @@
-import {DEFAULT_MIN_NOTE} from '$lib/earbetter/level.js';
+import {DEFAULT_MIN_NOTE} from '$lib/earbetter/level.svelte.js';
 import {Project_Data} from '$lib/earbetter/project.js';
 import {to_default_scale_realm} from '$lib/earbetter/realm_helpers.js';
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,7 +6,6 @@
 	import Themed from '@ryanatkn/fuz/Themed.svelte';
 	import {is_editable, swallow} from '@ryanatkn/belt/dom.js';
 	import Dialog from '@ryanatkn/fuz/Dialog.svelte';
-	import {effect as preact_effect, untracked} from '@preact/signals-core';
 	import {sync_color_scheme, Themer} from '@ryanatkn/fuz/theme.svelte.js';
 	import type {Snippet} from 'svelte';
 	import {page} from '$app/stores';
@@ -66,17 +65,25 @@
 		key: app.key.value,
 	});
 
-	preact_effect(() => set_in_storage(SITE_DATA_STORAGE_KEY, to_site_data()));
+	// TODO @multiple probably refactor, maybe combining the two into one piece of state
+	let inited_site_data_save = false;
+	$effect(() => {
+		if (inited_site_data_save) {
+			set_in_storage(SITE_DATA_STORAGE_KEY, to_site_data());
+		} else {
+			inited_site_data_save = true;
+		}
+	});
 
-	// TODO hacky but lets us avoid saving on init, what's a cleaner pattern? doesn't make sense to put in `app`
-	let inited_save = false;
-	preact_effect(() => {
-		if (untracked(() => inited_save)) {
+	// TODO @multiple probably refactor, maybe combining the two into one piece of state
+	let inited_app_save = false;
+	$effect(() => {
+		if (inited_app_save) {
 			app.save();
 		} else {
-			inited_save = true;
+			inited_app_save = true;
 		}
-	}); // TODO do effects like this need to be cleaned up or is calling dispose only for special cases?
+	});
 
 	// TODO refactor
 	const keydown = (e: KeyboardEvent) => {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,7 +7,7 @@
 	import {is_editable, swallow} from '@ryanatkn/belt/dom.js';
 	import Dialog from '@ryanatkn/fuz/Dialog.svelte';
 	import {sync_color_scheme, Themer} from '@ryanatkn/fuz/theme.svelte.js';
-	import type {Snippet} from 'svelte';
+	import {untrack, type Snippet} from 'svelte';
 	import {page} from '$app/stores';
 	import {BROWSER} from 'esm-env';
 
@@ -53,7 +53,8 @@
 		return parsed.success ? parsed.data : null;
 	});
 	$effect(() => {
-		app.set_active_level_data(current_level_hash_data?.level ?? null);
+		const d = current_level_hash_data;
+		untrack(() => app.set_active_level_data(d?.level ?? null));
 	});
 
 	// save site data

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -14,13 +14,13 @@
 	import {set_audio_context} from '$lib/audio_context.js';
 	import {adjust_volume} from '$lib/audio_helpers.js';
 	import {request_access} from '$lib/midi_access.js';
-	import {App, set_app} from '$lib/earbetter/app.js';
+	import {App, set_app} from '$lib/earbetter/app.svelte.js';
 	import {load_from_storage, set_in_storage} from '$lib/storage.js';
 	import {Site_Data} from '$routes/site_data.js';
 	import Init_Audio_Context from '$lib/Init_Audio_Context.svelte';
 	import Main_Menu from '$routes/Main_Menu.svelte';
 	import {set_main_menu} from '$routes/main_menu_state.svelte.js';
-	import {Level_Hash_Data} from '$lib/earbetter/level.js';
+	import {Level_Hash_Data} from '$lib/earbetter/level.svelte.js';
 	import {parse_from_hash} from '$lib/url.js';
 
 	interface Props {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -59,17 +59,18 @@
 	// save site data
 	const to_site_data = (): Site_Data => ({
 		// note these have to use `.value`, the `$`-prefix doesn't work for reactivity
-		volume: app.volume.value,
-		instrument: app.instrument.value,
-		scale: app.scale.value,
-		key: app.key.value,
+		volume: app.volume,
+		instrument: app.instrument,
+		scale: app.scale,
+		key: app.key,
 	});
 
 	// TODO @multiple probably refactor, maybe combining the two into one piece of state
 	let inited_site_data_save = false;
 	$effect(() => {
+		const site_data = to_site_data();
 		if (inited_site_data_save) {
-			set_in_storage(SITE_DATA_STORAGE_KEY, to_site_data());
+			set_in_storage(SITE_DATA_STORAGE_KEY, site_data);
 		} else {
 			inited_site_data_save = true;
 		}
@@ -78,8 +79,9 @@
 	// TODO @multiple probably refactor, maybe combining the two into one piece of state
 	let inited_app_save = false;
 	$effect(() => {
+		const data = app.toJSON();
 		if (inited_app_save) {
-			app.save();
+			app.save(data);
 		} else {
 			inited_app_save = true;
 		}
@@ -98,22 +100,22 @@
 			}
 			case '1': {
 				swallow(e);
-				app.instrument.value = 'sawtooth';
+				app.instrument = 'sawtooth';
 				return;
 			}
 			case '2': {
 				swallow(e);
-				app.instrument.value = 'sine';
+				app.instrument = 'sine';
 				return;
 			}
 			case '3': {
 				swallow(e);
-				app.instrument.value = 'square';
+				app.instrument = 'square';
 				return;
 			}
 			case '4': {
 				swallow(e);
-				app.instrument.value = 'triangle';
+				app.instrument = 'triangle';
 				return;
 			}
 			case 'ArrowUp': {

--- a/src/routes/Main_Menu.svelte
+++ b/src/routes/Main_Menu.svelte
@@ -55,7 +55,7 @@
 	<section>
 		<h2 class="section_title">settings</h2>
 		<form class="section_body">
-			<Volume_Control volume={app.volume} />
+			<Volume_Control bind:volume={app.volume} />
 			<Instrument_Control instrument={app.instrument} />
 			<aside>Earbetter supports MIDI devices like piano keyboards, connect and click:</aside>
 			<Init_Midi_Button midi_state={app} />

--- a/src/routes/Main_Menu.svelte
+++ b/src/routes/Main_Menu.svelte
@@ -56,7 +56,7 @@
 		<h2 class="section_title">settings</h2>
 		<form class="section_body">
 			<Volume_Control bind:volume={app.volume} />
-			<Instrument_Control instrument={app.instrument} />
+			<Instrument_Control bind:instrument={app.instrument} />
 			<aside>Earbetter supports MIDI devices like piano keyboards, connect and click:</aside>
 			<Init_Midi_Button midi_state={app} />
 		</form>

--- a/src/routes/Main_Menu.svelte
+++ b/src/routes/Main_Menu.svelte
@@ -23,7 +23,6 @@
 	 */
 
 	const app = get_app();
-	const {volume, instrument} = app;
 
 	const main_menu = get_main_menu();
 	afterNavigate(() => main_menu.opened && main_menu.close());
@@ -56,8 +55,8 @@
 	<section>
 		<h2 class="section_title">settings</h2>
 		<form class="section_body">
-			<Volume_Control {volume} />
-			<Instrument_Control {instrument} />
+			<Volume_Control volume={app.volume} />
+			<Instrument_Control instrument={app.instrument} />
 			<aside>Earbetter supports MIDI devices like piano keyboards, connect and click:</aside>
 			<Init_Midi_Button midi_state={app} />
 		</form>

--- a/src/routes/Main_Menu.svelte
+++ b/src/routes/Main_Menu.svelte
@@ -14,7 +14,7 @@
 	import Footer from '$routes/Footer.svelte';
 	import Site_Breadcrumb from '$routes/Site_Breadcrumb.svelte';
 	import {get_main_menu} from '$routes/main_menu_state.svelte.js';
-	import {get_app} from '$lib/earbetter/app.js';
+	import {get_app} from '$lib/earbetter/app.svelte.js';
 
 	// TODO @multiple let any routes (and components?) add sections to the menu via snippets
 

--- a/src/routes/piano/+page.svelte
+++ b/src/routes/piano/+page.svelte
@@ -35,8 +35,8 @@
 		Piano_Settings.parse,
 	);
 
-	const min_note = $state(initial_piano_settings.min_note);
-	const max_note = $state(initial_piano_settings.max_note);
+	let min_note = $state(initial_piano_settings.min_note);
+	let max_note = $state(initial_piano_settings.max_note);
 
 	const to_piano_data = (): Piano_Settings => ({min_note, max_note});
 	const save_piano_data = () => set_in_storage(SITE_DATA_STORAGE_KEY, to_piano_data());
@@ -96,7 +96,7 @@
 			<Init_Midi_Button midi_state={app} />
 		</fieldset>
 		<fieldset class="row">
-			<Midi_Range_Control {min_note} {max_note} />
+			<Midi_Range_Control bind:min_note bind:max_note />
 		</fieldset>
 	</form>
 	<Footer />

--- a/src/routes/piano/+page.svelte
+++ b/src/routes/piano/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import {z} from 'zod';
-	import {effect, signal} from '@preact/signals-core';
 	import {goto} from '$app/navigation';
 	import {base} from '$app/paths';
 
@@ -37,15 +36,12 @@
 		Piano_Settings.parse,
 	);
 
-	const min_note = signal(initial_piano_settings.min_note);
-	const max_note = signal(initial_piano_settings.max_note);
+	const min_note = $state(initial_piano_settings.min_note);
+	const max_note = $state(initial_piano_settings.max_note);
 
-	const to_piano_data = (): Piano_Settings => ({
-		min_note: min_note.value,
-		max_note: max_note.value,
-	});
+	const to_piano_data = (): Piano_Settings => ({min_note, max_note});
 	const save_piano_data = () => set_in_storage(SITE_DATA_STORAGE_KEY, to_piano_data());
-	effect(save_piano_data);
+	$effect(save_piano_data);
 
 	const ac = get_audio_context();
 
@@ -78,8 +74,8 @@
 		{#if clientWidth}
 			<Piano
 				width={clientWidth - piano_padding * 2}
-				min_note={$min_note}
-				max_note={$max_note}
+				{min_note}
+				{max_note}
 				{pressed_keys}
 				enabled_notes={$enabled_notes}
 				onpress={(note) => play(note)}

--- a/src/routes/piano/+page.svelte
+++ b/src/routes/piano/+page.svelte
@@ -86,7 +86,7 @@
 	</div>
 	<form class="width_sm panel p_md">
 		<fieldset>
-			<Instrument_Control instrument={app.instrument} />
+			<Instrument_Control bind:instrument={app.instrument} />
 			<div class="row">
 				<Select_Notes_Control scale={app.scale} key={app.key} />
 			</div>

--- a/src/routes/piano/+page.svelte
+++ b/src/routes/piano/+page.svelte
@@ -88,7 +88,7 @@
 		<fieldset>
 			<Instrument_Control bind:instrument={app.instrument} />
 			<div class="row">
-				<Select_Notes_Control scale={app.scale} key={app.key} />
+				<Select_Notes_Control bind:scale={app.scale} bind:key={app.key} />
 			</div>
 			<Volume_Control bind:volume={app.volume} />
 		</fieldset>

--- a/src/routes/piano/+page.svelte
+++ b/src/routes/piano/+page.svelte
@@ -90,7 +90,7 @@
 			<div class="row">
 				<Select_Notes_Control scale={app.scale} key={app.key} />
 			</div>
-			<Volume_Control volume={app.volume} />
+			<Volume_Control bind:volume={app.volume} />
 		</fieldset>
 		<fieldset>
 			<Init_Midi_Button midi_state={app} />

--- a/src/routes/piano/+page.svelte
+++ b/src/routes/piano/+page.svelte
@@ -18,7 +18,7 @@
 	import Select_Notes_Control from '$lib/Select_Notes_Control.svelte';
 	import {load_from_storage, set_in_storage} from '$lib/storage.js';
 	import Back_Button from '$routes/Back_Button.svelte';
-	import {get_app} from '$lib/earbetter/app.js';
+	import {get_app} from '$lib/earbetter/app.svelte.js';
 
 	const app = get_app();
 

--- a/src/routes/piano/+page.svelte
+++ b/src/routes/piano/+page.svelte
@@ -21,7 +21,6 @@
 	import {get_app} from '$lib/earbetter/app.js';
 
 	const app = get_app();
-	const {playing_notes, midi_access, volume, instrument, scale, key, enabled_notes} = $derived(app);
 
 	// TODO extract? is pretty specific
 	const Piano_Settings = z.object({
@@ -45,15 +44,15 @@
 
 	const ac = get_audio_context();
 
-	const pressed_keys = $derived($playing_notes);
+	const pressed_keys = $derived(app.playing_notes);
 
 	let clientWidth: number | undefined = $state();
 
 	const piano_padding = 20;
 
 	const play = (note: Midi, velocity: number | null = null): void => {
-		if (!$enabled_notes || $enabled_notes.has(note)) {
-			start_playing(app, ac(), note, with_velocity($volume, velocity), $instrument);
+		if (!app.enabled_notes || app.enabled_notes.has(note)) {
+			start_playing(app, ac(), note, with_velocity(app.volume, velocity), app.instrument);
 		}
 	};
 </script>
@@ -63,7 +62,7 @@
 </svelte:head>
 
 <Midi_Input
-	{midi_access}
+	midi_access={app.midi_access}
 	onnotestart={(note, velocity) => play(note, velocity)}
 	onnotestop={(note) => stop_playing(note)}
 />
@@ -77,7 +76,7 @@
 				{min_note}
 				{max_note}
 				{pressed_keys}
-				enabled_notes={$enabled_notes}
+				enabled_notes={app.enabled_notes}
 				onpress={(note) => play(note)}
 				onrelease={(note) => stop_playing(note)}
 				middle_c_label
@@ -87,11 +86,11 @@
 	</div>
 	<form class="width_sm panel p_md">
 		<fieldset>
-			<Instrument_Control {instrument} />
+			<Instrument_Control instrument={app.instrument} />
 			<div class="row">
-				<Select_Notes_Control {scale} {key} />
+				<Select_Notes_Control scale={app.scale} key={app.key} />
 			</div>
-			<Volume_Control {volume} />
+			<Volume_Control volume={app.volume} />
 		</fieldset>
 		<fieldset>
 			<Init_Midi_Button midi_state={app} />

--- a/src/routes/trainer/+page.svelte
+++ b/src/routes/trainer/+page.svelte
@@ -4,7 +4,7 @@
 
 	import Header from '$routes/Header.svelte';
 	import Footer from '$routes/Footer.svelte';
-	import {get_app} from '$lib/earbetter/app.js';
+	import {get_app} from '$lib/earbetter/app.svelte.js';
 	import Level_Map from '$lib/earbetter/Level_Map.svelte';
 	import Back_Button from '$routes/Back_Button.svelte';
 

--- a/src/routes/trainer/level/+page.svelte
+++ b/src/routes/trainer/level/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Level_Scene from '$lib/earbetter/Level_Scene.svelte';
-	import {get_app} from '$lib/earbetter/app.js';
+	import {get_app} from '$lib/earbetter/app.svelte.js';
 	import Back_Button from '$routes/Back_Button.svelte';
 
 	const app = get_app();

--- a/src/routes/trainer/level/+page.svelte
+++ b/src/routes/trainer/level/+page.svelte
@@ -5,9 +5,7 @@
 
 	const app = get_app();
 
-	const {level, exit_level, selected_project_data} = $derived(app);
-
-	const level_stats = $derived($selected_project_data?.level_stats);
+	const level_stats = $derived(app.selected_project_data?.level_stats);
 </script>
 
 <svelte:head>
@@ -16,9 +14,9 @@
 
 <main>
 	<Back_Button onclick={app.exit_level} />
-	{#if $level && level_stats}
+	{#if app.level && level_stats}
 		<div class="level">
-			<Level_Scene level={$level} {level_stats} {exit_level} />
+			<Level_Scene level={app.level} {level_stats} exit_level={app.exit_level} />
 		</div>
 	{:else}
 		<div class="box h_100">


### PR DESCRIPTION
Converts from using the stores from [Preact Signals](https://github.com/preactjs/signals) (`@preact/signals-core`) to Svelte 5 runes.

Video walkthrough of the PR: [youtube.com/watch?v=IsJtmbvW2SI](https://www.youtube.com/watch?v=IsJtmbvW2SI)

Here's [the Svelte 5 REPL](https://svelte-5-preview.vercel.app/#H4sIAAAAAAAACq2V366iMBDGX2W2MSnmgF7tjaJZ9zXUmBZGbQKFtMXdE8K7bwA5Aq3iSfbCC2a--cP3s6UkZ5GgJqt9SSRLkazILs-JT8xnXj_oGyYGiU90VqiojoQ6UiI324M8GJHmmTJQanGRLPEhytK8MBj7gOczRgaYhlwhi8ypDfjAmYmuFZxVlgL91SaXbb0OokwhXfc7_1HCMJ6gDzEqccO4K20XW2rzVVL_okzqLMFFkl08GgRblAZVt0Ihm-EY0_m6ExsreWKwgXYhj7LXUt6T8omutbbzx_PmsNk6RIsbSwqED6BA4cMxsBW0kwbO3luWjRNDH9y7OPuzwYBqMMdecwN0R90S_pD8pmsLTRgE-FfYNrUeToF8gfFtiG8jfAPgBL7_Ae8ZupfgmuSw95ONHyQtiU2ymk8CfQ9ne4Z_nlQhUd-9T9AM4w3KmTbM4AOlreI91ZDjqFsjvF8m3nhSR27Uu203m4TlGGV3Y3wAyX7ZDoX9gi_PksPNSeeb61M77WpTzULdJTw-SiMpH0jdELqutbaDsB8nfavz0Qdvz3zgx8b7B6hvo-kvUDeYWYkBHSvd4zPOvU2o53q4fHxOZfgjCGAXx0JewFxRI8QZakkNRFcmLwgcr-wmMgUcI1ZorFWfVCHkRZJgXD-CZimCESnWH9-7L4uDDGNx2zru-xWUM0e4Cpd1wbDOWfWsZvynX0E5DrkLvkDUQ6zgvQaCYEt8kmaxOAuMycqoAqtj9Q9PNELR0AgAAA==) comparing Svelte runes batching with Preact batched and unbatched.

- `batch()` was already removed in #32 
- can't destructure primitives because they're no longer wrapped in a store
- `.peek()` is like `untrack` but maybe not needed in most cases
- all `$effect` are suspect

Followups:

- change from immutable patterns to using the reactive `SvelteSet` and `SvelteMap`, and possibly proxied POJOs/arrays elsewhere
- lots of form cleanup - pattern of binding vs callbacks vs both