### PR TITLE
followup to Svelte 5 runes conversion from Preact Signals stores

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@sveltejs/adapter-static": "^3.0.2",
         "@sveltejs/kit": "^2.5.18",
         "@sveltejs/vite-plugin-svelte": "^3.1.1",
+        "dequal": "^2.0.3",
         "eslint": "^9.6.0",
         "eslint-plugin-svelte": "^2.41.0",
         "esm-env": "^1.0.0",
@@ -1048,6 +1049,8 @@
     },
     "node_modules/dequal": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@sveltejs/adapter-static": "^3.0.2",
     "@sveltejs/kit": "^2.5.18",
     "@sveltejs/vite-plugin-svelte": "^3.1.1",
+    "dequal": "^2.0.3",
     "eslint": "^9.6.0",
     "eslint-plugin-svelte": "^2.41.0",
     "esm-env": "^1.0.0",

--- a/src/lib/Intervals_Input.svelte
+++ b/src/lib/Intervals_Input.svelte
@@ -29,17 +29,13 @@
 	}: Props = $props();
 
 	// TODO visualize the intervals with a piano
-	const updated_intervals: Intervals = $derived(to_scale_notes(scale, octaves));
-
-	// TODO extract helpers
+	const intervals_from_scale_and_octave = $derived(to_scale_notes(scale, octaves));
 
 	let input_intervals_str = $state(serialize_intervals(intervals));
 	const parsed_input_intervals = $derived(parse_intervals(input_intervals_str));
 
 	const changed = $derived(!dequal(intervals, parsed_input_intervals));
 	const valid = $derived(!!parsed_input_intervals.length);
-
-	// TODO next UX: discard/use buttons where the latter gets disabled, and a cancel button if unchanged
 </script>
 
 <small

--- a/src/lib/Intervals_Input.svelte
+++ b/src/lib/Intervals_Input.svelte
@@ -1,57 +1,45 @@
 <script lang="ts">
-	import {Intervals, Scale, scales, to_scale_notes} from '$lib/music.js';
+	import {
+		DEFAULT_SCALE,
+		Intervals,
+		lookup_scale,
+		Scale,
+		scales,
+		to_scale_notes,
+	} from '$lib/music.js';
 
 	// TODO @multiple naming convention between `Intervals_Input`/`Notes_Input`/`Select_Notes_Control`?
 
 	interface Props {
 		scale?: Scale;
 		octaves?: number;
-		onscale?: (scale: Scale) => void;
-		onoctaves?: (octaves: number) => void;
 		oninput?: (intervals: Intervals, scale: Scale, octaves: number) => void;
 	}
 
-	const {scale = scales[0], octaves = 1, onscale, onoctaves, oninput}: Props = $props();
-
-	let updated_scale: Scale = $state.frozen(scale);
-
-	let updated_octaves: number = $state(octaves);
+	let {scale = $bindable(DEFAULT_SCALE), octaves = $bindable(1), oninput}: Props = $props();
 
 	// TODO visualize the intervals with a piano
-	const intervals: Intervals = $derived(to_scale_notes(updated_scale, updated_octaves));
+	const intervals: Intervals = $derived(to_scale_notes(scale, octaves));
 
-	// TODO @multiple review this effect to try to remove it
-	$effect(() => {
-		updated_scale = scale;
-		if (scale !== updated_scale) {
-			console.log('onscale', updated_scale);
-			onscale?.(updated_scale);
-		}
-	});
-	$effect(() => {
-		updated_octaves = octaves;
-		if (octaves !== updated_octaves) {
-			console.log('onoctaves', updated_octaves);
-			onoctaves?.(updated_octaves);
-		}
-	});
+	// TODO next UX: discard/use buttons where the latter gets disabled, and a cancel button if unchanged
 </script>
 
 <label>
 	<div class="title text_align_center">scale</div>
-	<select bind:value={updated_scale}>
+	<!-- TODO bind the objects not the names to simplify -->
+	<select value={scale.name} oninput={(e) => (scale = lookup_scale(e.currentTarget.value))}>
 		{#each scales as s (s)}
-			<option value={s}>{s.name}</option>
+			<option value={s.name}>{s.name}</option>
 		{/each}
 	</select>
 </label>
 <label>
 	<div class="title text_align_center">octaves</div>
-	<div class="text_align_center">{updated_octaves}</div>
-	<input type="range" min={1} max={6} bind:value={updated_octaves} />
+	<div class="text_align_center">{octaves}</div>
+	<input type="range" min={1} max={6} bind:value={octaves} />
 </label>
 <small class="preview width_sm panel">{intervals.join(', ')}</small>
-<button type="button" onclick={() => oninput?.(intervals, updated_scale, updated_octaves)}>
+<button type="button" onclick={() => oninput?.(intervals, scale, octaves)}>
 	use these intervals
 </button>
 

--- a/src/lib/Intervals_Input.svelte
+++ b/src/lib/Intervals_Input.svelte
@@ -30,7 +30,7 @@
 
 	// TODO visualize the intervals with a piano
 	const intervals_from_scale_and_octave = $derived(to_scale_notes(scale, octaves));
-	const serizlized_intervals_from_scale_and_octave = $derived(
+	const serialized_intervals_from_scale_and_octave = $derived(
 		serialize_intervals(intervals_from_scale_and_octave),
 	);
 
@@ -50,7 +50,7 @@
 	const current_str = $derived(
 		last_time_intervals_changed >= last_time_intervals_from_scale_and_octave_changed
 			? input_intervals_str
-			: serizlized_intervals_from_scale_and_octave,
+			: serialized_intervals_from_scale_and_octave,
 	);
 	const current_intervals = $derived(parse_intervals(current_str));
 

--- a/src/lib/Intervals_Input.svelte
+++ b/src/lib/Intervals_Input.svelte
@@ -37,6 +37,7 @@
 	const serialized_intervals = $state(serialize_intervals(intervals));
 	let input_intervals_str = $state(serialized_intervals);
 
+	// TODO maybe on init, we should figure out a way to use the intervals from the scale and octave when appropriate, but I can't think of when that is right now
 	// The order here matters, on init we want the prop intervals to be the source of truth.
 	const last_time_intervals_from_scale_and_octave_changed = $derived.by(() => {
 		intervals_from_scale_and_octave;

--- a/src/lib/Intervals_Input.svelte
+++ b/src/lib/Intervals_Input.svelte
@@ -1,33 +1,66 @@
 <script lang="ts">
+	import {dequal} from 'dequal';
+
 	import {
 		DEFAULT_SCALE,
 		Intervals,
 		lookup_scale,
+		parse_intervals,
 		Scale,
 		scales,
+		serialize_intervals,
 		to_scale_notes,
 	} from '$lib/music.js';
 
 	// TODO @multiple naming convention between `Intervals_Input`/`Notes_Input`/`Select_Notes_Control`?
 
 	interface Props {
+		intervals: Intervals;
 		scale?: Scale;
 		octaves?: number;
 		oninput?: (intervals: Intervals, scale: Scale, octaves: number) => void;
 	}
 
-	let {scale = $bindable(DEFAULT_SCALE), octaves = $bindable(1), oninput}: Props = $props();
+	let {
+		intervals,
+		scale = $bindable(DEFAULT_SCALE),
+		octaves = $bindable(1),
+		oninput,
+	}: Props = $props();
 
 	// TODO visualize the intervals with a piano
-	const intervals: Intervals = $derived(to_scale_notes(scale, octaves));
+	const updated_intervals: Intervals = $derived(to_scale_notes(scale, octaves));
+
+	// TODO extract helpers
+
+	let input_intervals_str = $state(serialize_intervals(intervals));
+	const parsed_input_intervals = $derived(parse_intervals(input_intervals_str));
+
+	const changed = $derived(!dequal(intervals, parsed_input_intervals));
+	const valid = $derived(!!parsed_input_intervals.length);
 
 	// TODO next UX: discard/use buttons where the latter gets disabled, and a cancel button if unchanged
 </script>
 
+<small
+	><textarea
+		value={input_intervals_str}
+		oninput={(e) => (input_intervals_str = e.currentTarget.value)}
+		class="preview width_sm panel"
+	></textarea></small
+>
+<button
+	type="button"
+	class="mb_lg"
+	disabled={!changed || !valid}
+	onclick={() => oninput?.(parse_intervals(input_intervals_str), scale, octaves)}
+>
+	use these intervals
+</button>
 <label>
 	<div class="title text_align_center">scale</div>
 	<!-- TODO bind the objects not the names to simplify -->
-	<select value={scale.name} oninput={(e) => (scale = lookup_scale(e.currentTarget.value))}>
+	<select value={scale.name} onchange={(e) => (scale = lookup_scale(e.currentTarget.value))}>
 		{#each scales as s (s)}
 			<option value={s.name}>{s.name}</option>
 		{/each}
@@ -38,17 +71,12 @@
 	<div class="text_align_center">{octaves}</div>
 	<input type="range" min={1} max={6} bind:value={octaves} />
 </label>
-<small class="preview width_sm panel">{intervals.join(', ')}</small>
-<button type="button" onclick={() => oninput?.(intervals, scale, octaves)}>
-	use these intervals
-</button>
 
 <style>
 	/* TODO this is hacky, extract or reuse something? */
 	.preview {
 		padding: var(--space_md);
-		margin-bottom: var(--space_lg);
-		text-align: center;
+		margin: var(--space_lg) 0;
 		font-family: var(--font_mono);
 	}
 </style>

--- a/src/lib/Intervals_Input.svelte
+++ b/src/lib/Intervals_Input.svelte
@@ -23,21 +23,13 @@
 	// TODO @multiple review this effect to try to remove it
 	$effect(() => {
 		updated_scale = scale;
-		// TODO probably `onscale?.(updated_scale);`
-	});
-	$effect(() => {
-		updated_octaves = octaves;
-		// TODO probably `onoctaves?.(updated_octaves);`
-	});
-	// TODO @multiple review this effect to try to remove it
-	// TODO (look above) hacky, could use oninput handlers but
-	// the scale select needs to wait a tick to get `updated_scale`,
-	// unlike the octave range input, maybe a bug?
-	$effect(() => {
 		if (scale !== updated_scale) {
 			console.log('onscale', updated_scale);
 			onscale?.(updated_scale);
 		}
+	});
+	$effect(() => {
+		updated_octaves = octaves;
 		if (octaves !== updated_octaves) {
 			console.log('onoctaves', updated_octaves);
 			onoctaves?.(updated_octaves);

--- a/src/lib/Midi_Range_Control.svelte
+++ b/src/lib/Midi_Range_Control.svelte
@@ -14,10 +14,6 @@
 	const error_message = $derived(
 		min_note > max_note ? 'note min cannot be larger than the max' : false,
 	);
-
-	// TODO @multiple see about using `bind:` below if the types are correct
-	const input_min_note = (e: any) => (min_note = Number(e.currentTarget.value));
-	const input_max_note = (e: any) => (max_note = Number(e.currentTarget.value));
 </script>
 
 <div class="midi-range-control" class:error={!!error_message}>
@@ -25,42 +21,14 @@
 		<label class="text_align_center">
 			<div class="title">lowest note</div>
 			<div>{midi_names[min_note]}</div>
-			<input
-				type="range"
-				value={min_note}
-				oninput={input_min_note}
-				step={1}
-				min={MIDI_MIN}
-				max={MIDI_MAX}
-			/>
-			<input
-				type="number"
-				value={min_note}
-				oninput={input_min_note}
-				step={1}
-				min={MIDI_MIN}
-				max={MIDI_MAX}
-			/>
+			<input type="range" bind:value={min_note} step={1} min={MIDI_MIN} max={MIDI_MAX} />
+			<input type="number" bind:value={min_note} step={1} min={MIDI_MIN} max={MIDI_MAX} />
 		</label>
 		<label class="text_align_center">
 			<div class="title">highest note</div>
 			<div>{midi_names[max_note]}</div>
-			<input
-				type="range"
-				value={max_note}
-				oninput={input_max_note}
-				step={1}
-				min={MIDI_MIN}
-				max={MIDI_MAX}
-			/>
-			<input
-				type="number"
-				value={max_note}
-				oninput={input_max_note}
-				step={1}
-				min={MIDI_MIN}
-				max={MIDI_MAX}
-			/>
+			<input type="range" bind:value={max_note} step={1} min={MIDI_MIN} max={MIDI_MAX} />
+			<input type="number" bind:value={max_note} step={1} min={MIDI_MIN} max={MIDI_MAX} />
 		</label>
 	</div>
 	{#if error_message}

--- a/src/lib/Notes_Input.svelte
+++ b/src/lib/Notes_Input.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import {plural} from '@ryanatkn/belt/string.js';
+	import type {Snippet} from 'svelte';
 
 	import Piano from '$lib/Piano.svelte';
 	import {get_audio_context} from '$lib/audio_context.js';
@@ -33,10 +34,11 @@
 		notes: Set<Midi>;
 		min_note: Midi;
 		max_note: Midi;
+		before_buttons: Snippet;
 		oninput?: (notes: Midi[] | null) => void; // TODO @multiple set reactivity - API is strange returning an array but taking a set (maybe return both?)
 	}
 
-	const {audio_state, notes, min_note, max_note, oninput}: Props = $props();
+	const {audio_state, notes, min_note, max_note, before_buttons, oninput}: Props = $props();
 
 	// TODO @multiple set reactivity - refactor these collections to use `svelte/reactivity` sets instead of cloning, upstream and downstream where appropriate
 
@@ -182,6 +184,7 @@
 </div>
 
 {#snippet buttons()}
+	{#if before_buttons}{@render before_buttons()}{/if}
 	<button
 		class="mb_lg"
 		type="button"

--- a/src/lib/Select_Notes_Control.svelte
+++ b/src/lib/Select_Notes_Control.svelte
@@ -20,14 +20,12 @@
 	$inspect('scale', scale);
 
 	// TODO @multiple event callback or $bindable here and below
-	const input_key = (e: Event & {currentTarget: HTMLSelectElement}) =>
-		(scale = lookup_scale(e.currentTarget.value));
 </script>
 
 <label class="text_align_center">
 	<div class="title">scale</div>
 	<!-- TODO bind the objects not the names to simplify -->
-	<select value={scale.name} oninput={input_key}>
+	<select value={scale.name} oninput={(e) => (scale = lookup_scale(e.currentTarget.value))}>
 		{#each scales as s (s)}
 			<option value={s.name}>{s.name}</option>
 		{/each}

--- a/src/lib/Volume_Control.svelte
+++ b/src/lib/Volume_Control.svelte
@@ -7,26 +7,10 @@
 
 	// TODO add an `oninput` callback unless the `bind` restriction is lifted
 	let {volume = $bindable(DEFAULT_VOLUME)}: Props = $props();
-
-	// TODO @multiple see about using `bind:` below if the types are correct
 </script>
 
 <label class="text_align_center">
 	<div class="title">volume</div>
-	<input
-		type="number"
-		oninput={(e) => (volume = Number(e.currentTarget.value))}
-		step={0.01}
-		min={0}
-		max={1}
-		value={volume}
-	/>
-	<input
-		type="range"
-		oninput={(e) => (volume = Number(e.currentTarget.value))}
-		step={0.01}
-		min={0}
-		max={1}
-		value={volume}
-	/>
+	<input type="number" bind:value={volume} step={0.01} min={0} max={1} />
+	<input type="range" bind:value={volume} step={0.01} min={0} max={1} />
 </label>

--- a/src/lib/earbetter/Level_Form.svelte
+++ b/src/lib/earbetter/Level_Form.svelte
@@ -339,7 +339,9 @@
 		{#snippet children(close)}
 			<div class="bg shadow_d_xl p_xl width_md box">
 				<h2 class="my_0">pick intervals</h2>
+				<!-- TODO maybe `bind:intervals` and remove from `oninput`, but we still need oninput to close the dialog -->
 				<Intervals_Input
+					intervals={updated_intervals}
 					bind:scale
 					bind:octaves
 					oninput={(intervals) => {
@@ -347,6 +349,7 @@
 						close();
 					}}
 				/>
+				<button type="button" onclick={close}>cancel</button>
 			</div>
 		{/snippet}
 	</Dialog>

--- a/src/lib/earbetter/Level_Form.svelte
+++ b/src/lib/earbetter/Level_Form.svelte
@@ -11,10 +11,10 @@
 		MIDI_MIN,
 		type Midi,
 		midi_names,
-		Scale,
 		Intervals,
 		serialize_notes,
 		parse_notes,
+		DEFAULT_SCALE,
 	} from '$lib/music.js';
 	import Intervals_Input from '$lib/Intervals_Input.svelte';
 	import Notes_Input from '$lib/Notes_Input.svelte';
@@ -136,10 +136,8 @@
 	// use SvelteKit snapshots for that - https://kit.svelte.dev/docs/snapshots
 	// This is an object instead of as plain values because
 	// Svelte errors on the non-$state `let` updates, and that'll work well with snapshots.
-	const persisted: {scale: Scale | undefined; octaves: number | undefined} = {
-		scale: undefined,
-		octaves: undefined,
-	};
+	let scale = $state(DEFAULT_SCALE);
+	let octaves = $state(1);
 
 	// TODO helper component for measuring? with `let:width` - first look at Svelte's new box bindings
 	let piano_width: number | undefined = $state();
@@ -342,10 +340,8 @@
 			<div class="bg shadow_d_xl p_xl width_md box">
 				<h2 class="my_0">pick intervals</h2>
 				<Intervals_Input
-					scale={persisted.scale}
-					octaves={persisted.octaves}
-					onscale={(scale) => (persisted.scale = scale)}
-					onoctaves={(octaves) => (persisted.octaves = octaves)}
+					bind:scale
+					bind:octaves
 					oninput={(intervals) => {
 						updated_intervals = intervals;
 						close();
@@ -375,7 +371,11 @@
 						updated_tonics = notes;
 						close();
 					}}
-				/>
+				>
+					{#snippet before_buttons()}
+						<button type="button" class="mb_lg" onclick={close}>cancel</button>
+					{/snippet}
+				</Notes_Input>
 			</div>
 		{/snippet}
 	</Dialog>

--- a/src/lib/music.ts
+++ b/src/lib/music.ts
@@ -91,13 +91,18 @@ export type Semitones = Flavored<z.infer<typeof Semitones>, 'Semitones'>; // TOD
  */
 export const Intervals = z.array(Semitones);
 export type Intervals = Flavored<z.infer<typeof Intervals>, 'Intervals'>; // TODO @multiple this doesn't work when used as a schema, use z.brand() instead? or are the egonomics too bad?
-// TODO replace with zod
+// TODO replace with zod, also probably add a min/max
 export const serialize_intervals = (intervals: Intervals): string => intervals.join(', ');
 export const parse_intervals = (value: string): Intervals =>
-	value
-		.split(',')
-		.map((v) => Number(v.trim()) | 0)
-		.filter(Boolean); // exclude 0 intentionally
+	// TODO use a real `unique` helper
+	Array.from(
+		new Set(
+			value
+				.split(',')
+				.map((v) => parseInt(v, 10))
+				.filter((v) => !!v && v <= MIDI_MAX && v >= -MIDI_MAX), // exclude 0 intentionally
+		),
+	);
 
 /**
  * @see https://wikipedia.org/wiki/Natural_(music)

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -12,7 +12,6 @@
 	import {BROWSER} from 'esm-env';
 
 	import {set_audio_context} from '$lib/audio_context.js';
-	import {adjust_volume} from '$lib/audio_helpers.js';
 	import {request_access} from '$lib/midi_access.js';
 	import {App, set_app} from '$lib/earbetter/app.svelte.js';
 	import {load_from_storage, set_in_storage} from '$lib/storage.js';
@@ -117,16 +116,6 @@
 			case '4': {
 				swallow(e);
 				app.instrument = 'triangle';
-				return;
-			}
-			case 'ArrowUp': {
-				swallow(e);
-				adjust_volume(app);
-				return;
-			}
-			case 'ArrowDown': {
-				swallow(e);
-				adjust_volume(app, -1);
 				return;
 			}
 			case 'Escape': {


### PR DESCRIPTION
Follow to #37 

Cleans up some form stuff.

Followups:

- change from immutable patterns to using the reactive `SvelteSet` and `SvelteMap`, and possibly proxied POJOs/arrays elsewhere
- more form cleanup